### PR TITLE
Fix inclusion of SDL_net.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,14 @@ CFLAGS += -O2
 LDFLAGS := 
 LDLIBS := 
 
-SDL_CPPFLAGS := $(shell $(PKG_CONFIG) sdl --cflags)
-SDL_LDFLAGS := $(shell $(PKG_CONFIG) sdl --libs-only-L --libs-only-other)
-SDL_LDLIBS := $(shell $(PKG_CONFIG) sdl --libs-only-l)
 ifeq ($(WITH_NETWORK), true)
-    SDL_LDLIBS += -lSDL_net
+    SDL_CPPFLAGS := $(shell $(PKG_CONFIG) sdl SDL_net --cflags)
+    SDL_LDFLAGS := $(shell $(PKG_CONFIG) sdl SDL_net --libs-only-L --libs-only-other)
+    SDL_LDLIBS := $(shell $(PKG_CONFIG) sdl SDL_net --libs-only-l)
+else
+    SDL_CPPFLAGS := $(shell $(PKG_CONFIG) sdl --cflags)
+    SDL_LDFLAGS := $(shell $(PKG_CONFIG) sdl --libs-only-L --libs-only-other)
+    SDL_LDLIBS := $(shell $(PKG_CONFIG) sdl --libs-only-l)
 endif
 
 ALL_CPPFLAGS = -DTARGET_$(PLATFORM) \


### PR DESCRIPTION
```
In file included from src/params.c:25:
src/network.h:26:11: fatal error: SDL_net.h: No such file or directory
   26 | # include "SDL_net.h"
      |           ^~~~~~~~~~~
compilation terminate
```
Including `SDL_net` in pkgconfig's specification fixes the issue.