### PR TITLE
Fixed distribution CFLAGS getting overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ifneq ($(OPENTYRIAN_VERSION), )
 endif
 
 CPPFLAGS := -DNDEBUG
-CFLAGS := -pedantic
+CFLAGS += -pedantic
 CFLAGS += -MMD
 CFLAGS += -Wall \
           -Wextra \


### PR DESCRIPTION
This is a patch from @openSUSE.