### PR TITLE
Add `const` to arrays

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -358,7 +358,7 @@ const char *config_get_or_set_string_option( ConfigSection *section, const char 
 	return value;
 }
 
-static const char *bool_values[][2] = 
+static const char *const bool_values[][2] = 
 {
 	{ "0", "1" },
 	{ "no", "yes" },

--- a/src/destruct.c
+++ b/src/destruct.c
@@ -381,18 +381,18 @@ static struct destruct_shot_s   * shotRec;
 static struct destruct_explo_s  * exploRec;
 
 
-static const char *player_names[] =
+static const char *const player_names[] =
 {
 	"left", "right",
 };
 
-static const char *key_names[] =
+static const char *const key_names[] =
 {
 	"left", "right", "up", "down",
 	"change", "fire", "previous weapon", "next weapon",
 };
 
-static const char *unit_names[] =
+static const char *const unit_names[] =
 {
 	"tank", "nuke", "dirt", "satellite",
 	"magnet", "laser", "jumper", "heli",

--- a/src/file.c
+++ b/src/file.c
@@ -33,7 +33,7 @@ const char *custom_data_dir = NULL;
 // finds the Tyrian data directory
 const char *data_dir( void )
 {
-	const char *dirs[] =
+	const char *const dirs[] =
 	{
 		custom_data_dir,
 		TYRIAN_DIR,

--- a/src/game_menu.c
+++ b/src/game_menu.c
@@ -407,7 +407,7 @@ void JE_itemScreen( void )
 
 		if (curMenu == MENU_JOYSTICK_CONFIG)
 		{
-			const char *menu_item[] =
+			const char *const menu_item[] =
 			{
 				"JOYSTICK",
 				"ANALOG AXES",
@@ -2344,7 +2344,7 @@ void JE_drawMainMenuHelpText( void )
 	temp = curSel[curMenu] - 2;
 	if (curMenu == MENU_JOYSTICK_CONFIG) // joystick settings menu help
 	{
-		int help[16] = { 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 24, 11 };
+		const int help[16] = { 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 24, 11 };
 		memcpy(tempStr, mainMenuHelp[help[curSel[curMenu] - 2]], sizeof(tempStr));
 	}
 	else if (curMenu < MENU_PLAY_NEXT_LEVEL ||

--- a/src/network.c
+++ b/src/network.c
@@ -692,7 +692,7 @@ connect_again:
 // something has gone wrong :(
 void network_tyrian_halt( unsigned int err, bool attempt_sync )
 {
-	const char *err_msg[] = {
+	const char *const err_msg[] = {
 		"Quitting...",
 		"Other player quit the game.",
 		"Network connection was lost.",

--- a/src/opl.c
+++ b/src/opl.c
@@ -245,7 +245,7 @@ static const Bit8u regbase2op[22] = {
 
 
 // start of the waveform
-static Bit32u waveform[8] = {
+static const Bit32u waveform[8] = {
 	WAVEPREC,
 	WAVEPREC>>1,
 	WAVEPREC,
@@ -257,7 +257,7 @@ static Bit32u waveform[8] = {
 };
 
 // length of the waveform as mask
-static Bit32u wavemask[8] = {
+static const Bit32u wavemask[8] = {
 	WAVEPREC-1,
 	WAVEPREC-1,
 	(WAVEPREC>>1)-1,
@@ -269,7 +269,7 @@ static Bit32u wavemask[8] = {
 };
 
 // where the first entry resides
-static Bit32u wavestart[8] = {
+static const Bit32u wavestart[8] = {
 	0,
 	WAVEPREC>>1,
 	0,
@@ -281,13 +281,13 @@ static Bit32u wavestart[8] = {
 };
 
 // envelope generator function constants
-static fltype attackconst[4] = {
+static const fltype attackconst[4] = {
 	(fltype)(1/2.82624),
 	(fltype)(1/2.25280),
 	(fltype)(1/1.88416),
 	(fltype)(1/1.59744)
 };
-static fltype decrelconst[4] = {
+static const fltype decrelconst[4] = {
 	(fltype)(1/39.28064),
 	(fltype)(1/31.41608),
 	(fltype)(1/26.17344),
@@ -454,7 +454,7 @@ void operator_attack(op_type* op_pt) {
 
 typedef void (*optype_fptr)(op_type*);
 
-optype_fptr opfuncs[6] = {
+const optype_fptr opfuncs[6] = {
 	operator_attack,
 	operator_decay,
 	operator_release,
@@ -478,7 +478,7 @@ void change_attackrate(Bitu regbase, op_type* op_pt) {
 		op_pt->env_step_a = (1<<(steps<=12?12-steps:0))-1;
 
 		Bits step_num = (step_skip<=48)?(4-(step_skip&3)):0;
-		static Bit8u step_skip_mask[5] = {0xff, 0xfe, 0xee, 0xba, 0xaa}; 
+		static const Bit8u step_skip_mask[5] = {0xff, 0xfe, 0xee, 0xba, 0xaa}; 
 		op_pt->env_step_skip_a = step_skip_mask[step_num];
 
 #if defined(OPLTYPE_IS_OPL3)

--- a/src/palette.c
+++ b/src/palette.c
@@ -111,7 +111,7 @@ void step_fade_palette( int diff[256][3], int steps, unsigned int first_color, u
 	
 	for (unsigned int i = first_color; i <= last_color; i++)
 	{
-		int delta[3] = { diff[i][0] / steps, diff[i][1] / steps, diff[i][2] / steps };
+		const int delta[3] = { diff[i][0] / steps, diff[i][1] / steps, diff[i][2] / steps };
 		
 		diff[i][0] -= delta[0];
 		diff[i][1] -= delta[1];

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -3645,7 +3645,7 @@ bool newGame( void )
 		{
 			// allows player to smuggle arcade/super-arcade ships into full game
 
-			ulong initial_cash[] = { 10000, 15000, 20000, 30000 };
+			const ulong initial_cash[] = { 10000, 15000, 20000, 30000 };
 
 			assert(episodeNum >= 1 && episodeNum <= EPISODE_AVAILABLE);
 			player[0].cash = initial_cash[episodeNum - 1];
@@ -4325,7 +4325,7 @@ void JE_eventSystem( void )
 
 	case 5:  // load enemy shape banks
 		{
-			Uint8 newEnemyShapeTables[] =
+			const Uint8 newEnemyShapeTables[] =
 			{
 				eventRec[eventLoc-1].eventdat > 0 ? eventRec[eventLoc-1].eventdat : 0,
 				eventRec[eventLoc-1].eventdat2 > 0 ? eventRec[eventLoc-1].eventdat2 : 0,

--- a/src/video.c
+++ b/src/video.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-const char *scaling_mode_names[ScalingMode_MAX] = {
+const char *const scaling_mode_names[ScalingMode_MAX] = {
 	"Center",
 	"Integer",
 	"Fit 8:5",

--- a/src/video.h
+++ b/src/video.h
@@ -34,7 +34,7 @@ typedef enum {
 	ScalingMode_MAX
 } ScalingMode;
 
-extern const char *scaling_mode_names[ScalingMode_MAX];
+extern const char *const scaling_mode_names[ScalingMode_MAX];
 
 extern int fullscreen_display; // -1 means windowed
 extern ScalingMode scaling_mode;


### PR DESCRIPTION
I noticed that the codebase commonly marks arrays as top-level `const` when possible (which helps avoid unintentional modification, and can allow compilers to emit read-only data, especially when they're `static const`), but a few arrays weren't marked. This PR makes them consistent.