### PR TITLE
Remove unused `pcxfile` array

### DIFF
--- a/src/pcxmast.c
+++ b/src/pcxmast.c
@@ -20,23 +20,6 @@
 
 #include "opentyr.h"
 
-const char *pcxfile[PCX_NUM] = /* [1..PCXnum] */
-{
-	"INTSHPB.PCX",
-	"SETUP2.PCX",
-	"TYRPLAY.PCX",
-	"TYRLOG2.PCX",
-	"P1.PCX",
-	"TYRPLAY2.PCX",
-	"BUC4.PCX",
-	"GMOVR4a.PCX",
-	"GMOVR4b.PCX",
-	"EPICSKY.PCX",
-	"DESTRUCT.PCX",
-	"ECLIPSE.PCX",
-	"FIREPICA.PCX"
-};
-
 const JE_byte pcxpal[PCX_NUM] = /* [1..PCXnum] */
 { 0, 7, 5, 8, 10, 5, 18, 19, 19, 20, 21, 22, 5};
 

--- a/src/pcxmast.h
+++ b/src/pcxmast.h
@@ -26,7 +26,6 @@
 
 typedef JE_longint JE_pcxpostype[PCX_NUM + 1]; /* [1..PCXnum + 1] */
 
-extern const char *pcxfile[PCX_NUM]; /* [1..PCXnum] */
 extern const JE_byte pcxpal[PCX_NUM];    /* [1..PCXnum] */
 extern const JE_byte facepal[12];       /* [1..12] */
 extern JE_pcxpostype pcxpos;


### PR DESCRIPTION
I noticed that this was missing top-level `const`, but then I noticed that it was completely unused.