### PR TITLE
Remove dead code

### DIFF
--- a/src/animlib.c
+++ b/src/animlib.c
@@ -72,7 +72,6 @@ void JE_closeAnim( void );
 int JE_loadAnim( const char * );
 int JE_renderFrame( unsigned int );
 int JE_findPage ( unsigned int );
-int JE_drawFrame( unsigned int );
 int JE_loadPage( unsigned int );
 
 /*** Implementation ***/
@@ -120,20 +119,6 @@ int JE_loadPage( unsigned int pagenumber )
 	if(pageSize != CurrentPageHeader.nBytes) { return(-1); }
 
 	/* So far, so good */
-	return(0);
-}
-
-int JE_drawFrame( unsigned int framenumber )
-{
-	int ret;
-
-
-	ret = JE_loadPage(framenumber);
-	if (ret) { return(ret); }
-
-	ret = JE_renderFrame (framenumber);
-	if (ret) { return(ret); }
-
 	return(0);
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -617,7 +617,6 @@ void JE_setNewGameSpeed( void )
 		break;
 	}
 
-  frameCount = frameCountMax;
   JE_resetTimerInt();
   JE_setTimerInt();
 }

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -165,27 +165,6 @@ ConfigSection *config_add_section_len( Config *config, const char *type, size_t 
 	return section;
 }
 
-ConfigSection *config_find_sections( Config *config, const char *type, ConfigSection **save )
-{
-	assert(config != NULL);
-	assert(type != NULL);
-	
-	ConfigSection *sections_end = &config->sections[config->sections_count];
-	
-	ConfigSection *section = save != NULL && *save != NULL ?
-		*save :
-		&config->sections[0];
-	
-	for (; section < sections_end; ++section)
-		if (strcmp(config_string_to_cstr(&section->type), type) == 0)
-			break;
-	
-	if (save != NULL)
-		*save = section;
-	
-	return section < sections_end ? section : NULL;
-}
-
 ConfigSection *config_find_section( Config *config, const char *type, const char *name )
 {
 	assert(config != NULL);
@@ -351,13 +330,6 @@ bool config_get_string_option( const ConfigSection *section, const char *key, co
 	return false;
 }
 
-const char *config_get_or_set_string_option( ConfigSection *section, const char *key, const char *value )
-{
-	if (!config_get_string_option(section, key, &value))
-		config_set_string_option_len(section, key, strlen(key), value, value == NULL ? 0 : strlen(value));
-	return value;
-}
-
 static const char *bool_values[][2] = 
 {
 	{ "0", "1" },
@@ -473,13 +445,6 @@ bool config_get_uint_option( const ConfigSection *section, const char *key, unsi
 	}
 	
 	return false;
-}
-
-unsigned int config_get_or_set_uint_option( ConfigSection *section, const char *key, unsigned int value )
-{
-	if (!config_get_uint_option(section, key, &value))
-		config_set_uint_option(section, key, value);
-	return value;
 }
 
 /* config option accessors/manipulators -- by reference */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -332,10 +332,8 @@ bool config_get_string_option( const ConfigSection *section, const char *key, co
 
 static const char *bool_values[][2] = 
 {
-	{ "0", "1" },
 	{ "no", "yes" },
 	{ "off", "on" },
-	{ "false", "true" },
 };
 
 void config_set_bool_option( ConfigSection *section, const char *key, bool value, ConfigBoolStyle style )

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -521,19 +521,6 @@ static inline unsigned int config_get_value_count( const ConfigOption *option )
 /*!
  * \brief Iterate over the values assigned to the option.
  * 
- * \param[out] string_value the value variable to declare
- * \param[in] option the option
- */
-#define foreach_option_value( string_value, option ) \
-	for (ConfigOption *_option = (option); _option != NULL; _option = NULL) \
-	for (ConfigString *_values_begin = _option->values_count == 0 ? &_option->v.value : &_option->v.values[0], \
-	                  *_values_end = _option->values_count == 0 ? _values_begin + 1 : &_option->v.values[_option->values_count], \
-	                  *_value = _values_begin; _value < _values_end; ++_value) \
-	for (const char *(string_value) = config_string_to_cstr(_value); (string_value) != NULL; (string_value) = NULL)
-
-/*!
- * \brief Iterate over the values assigned to the option.
- * 
  * \param[out] i the index variable to declare
  * \param[out] string_value the value variable to declare
  * \param[in] option the option

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -349,10 +349,8 @@ extern bool config_get_string_option( const ConfigSection *section, const char *
  */
 typedef enum
 {
-	ZERO_ONE = 0,
-	NO_YES = 1,
-	OFF_ON = 2,
-	FALSE_TRUE = 3,
+	NO_YES = 0, // These values are used to index into the bool_values array.
+	OFF_ON = 1,
 } ConfigBoolStyle;
 
 /*!

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -251,17 +251,6 @@ static inline ConfigSection *config_add_section( Config *config, const char *typ
 // TODO: extern Config *config_remove_section( Config *config, unsigned int i );
 
 /*!
- * \brief Iterate sections by type.
- * 
- * \param[in] config the configuration containing the sections
- * \param[in] type the type of the section
- * \param[in,out] save the saved state of the iterator; initialize \c *save to \c NULL before
- *                     iteration
- * \return the section; \c NULL if iteration finished
- */
-extern ConfigSection *config_find_sections( Config *config, const char *type, ConfigSection **save );
-
-/*!
  * \brief Find a section by type and name.
  * 
  * \param[in] config the configuration containing the section
@@ -354,17 +343,6 @@ static inline void config_set_string_option( ConfigSection *section, const char 
  * \return whether \p out_value was set
  */
 extern bool config_get_string_option( const ConfigSection *section, const char *key, const char **out_value );
-
-/*!
- * \brief Get a string value of an 'item' option by key, setting the option if it was invalid or
- *        creating the option if it did not exist.
- * 
- * \param[in] section the section containing the option
- * \param[in] key the option key
- * \param[in] value the default item value
- * \return the value
- */
-extern const char *config_get_or_set_string_option( ConfigSection *section, const char *key, const char *value );
 
 /*!
  * \brief The styles of boolean values.
@@ -461,17 +439,6 @@ extern void config_set_uint_option( ConfigSection *section, const char *key, uns
  * \return whether \p out_value was set
  */
 extern bool config_get_uint_option( const ConfigSection *section, const char *key, unsigned int *out_value );
-
-/*!
- * \brief Get an unsigned integer value of an 'item' option by key, setting the option if it was
- *        invalid or creating the option if it did not exist.
- * 
- * \param[in] section the section containing the option
- * \param[in] key the option key
- * \param[in] value the default item value
- * \return the value
- */
-extern unsigned int config_get_or_set_uint_option( ConfigSection *section, const char *key, unsigned int value );
 
 /* config option accessors/manipulators -- by reference */
 

--- a/src/destruct.c
+++ b/src/destruct.c
@@ -66,7 +66,6 @@
 #include <assert.h>
 
 /*** Defines ***/
-#define UNIT_HEIGHT 12
 #define MAX_KEY_OPTIONS 4
 
 /*** Enums ***/

--- a/src/file.h
+++ b/src/file.h
@@ -146,37 +146,4 @@ static inline void fwrite_u16_die(const Uint16 *buffer, FILE *stream)
 	fwrite_die(buffer, sizeof(Uint16), 1, stream);
 }
 
-// 16-bit endian-swapping fwrite that dies if write fails
-static inline void fwrite_s16_die(const Sint16 *buffer, FILE *stream)
-{
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	Sint16 temp = SDL_Swap16(*buffer);
-	buffer = &temp;
-#endif
-
-	fwrite_die(buffer, sizeof(Sint16), 1, stream);
-}
-
-// 32-bit endian-swapping fwrite that dies if write fails
-static inline void fwrite_u32_die(const Uint32 *buffer, FILE *stream)
-{
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	Uint32 temp = SDL_Swap32(*buffer);
-	buffer = &temp;
-#endif
-
-	fwrite_die(buffer, sizeof(Uint32), 1, stream);
-}
-
-// 32-bit endian-swapping fwrite that dies if write fails
-static inline void fwrite_s32_die(const Sint32 *buffer, FILE *stream)
-{
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	Sint32 temp = SDL_Swap32(*buffer);
-	buffer = &temp;
-#endif
-
-	fwrite_die(buffer, sizeof(Sint32), 1, stream);
-}
-
 #endif // FILE_H

--- a/src/fonthand.h
+++ b/src/fonthand.h
@@ -27,7 +27,6 @@
 #define FULL_SHADE 1
 #define DARKEN     2
 #define TRICK      3
-#define NO_SHADE 255
 
 extern const int font_ascii[256];
 

--- a/src/game_menu.c
+++ b/src/game_menu.c
@@ -1085,7 +1085,6 @@ void JE_itemScreen( void )
 				curMenu = MENU_FULL_GAME;
 				JE_playSampleNum(S_SPRING);
 				newPal = 1;
-				JE_wipeKey();
 			}
 
 			if (curMenu == MENU_DATA_CUBE_SUB)
@@ -2379,8 +2378,6 @@ JE_boolean JE_quitRequest( void )
 {
 	bool quit_selected = true, done = false;
 
-	JE_clearKeyboard();
-	JE_wipeKey();
 	wait_noinput(true, true, true);
 
 	JE_barShade(VGAScreen, 65, 55, 255, 155);
@@ -2744,8 +2741,6 @@ void JE_menuFunction( JE_byte select )
 					keySettings[curSelect-2] = lastkey_scan;
 					++curSelect;
 				}
-				
-				JE_wipeKey();
 			}
 		}
 		break;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -253,9 +253,3 @@ void service_SDL_events( JE_boolean clear_new )
 		}
 	}
 }
-
-void JE_clearKeyboard( void )
-{
-	// /!\ Doesn't seems important. I think. D:
-}
-

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -54,7 +54,5 @@ void service_SDL_events( JE_boolean clear_new );
 
 void sleep_game( void );
 
-void JE_clearKeyboard( void );
-
 #endif /* KEYBOARD_H */
 

--- a/src/loudness.c
+++ b/src/loudness.c
@@ -44,8 +44,6 @@ SAMPLE_TYPE *channel_pos[SFX_CHANNELS] = { NULL };
 Uint32 channel_len[SFX_CHANNELS] = { 0 };
 Uint8 channel_vol[SFX_CHANNELS];
 
-int sound_init_state = false;
-
 static SDL_AudioDeviceID audio_device = 0;
 
 void audio_cb( void *user_data, unsigned char *sdl_buffer, int bytes_needed );

--- a/src/lvlmast.h
+++ b/src/lvlmast.h
@@ -25,21 +25,13 @@
 
 #define WEAP_NUM    780
 #define PORT_NUM    42
-#define ARMOR_NUM   4
 #define POWER_NUM   6
-#define ENGINE_NUM  6
 #define OPTION_NUM  30
 #define SHIP_NUM    13
 #define SHIELD_NUM  10
 #define SPECIAL_NUM 46
 
 #define ENEMY_NUM   850
-
-#define LVL_NUM   (18 * 2)
-#define LVL_NUM_2 (12 * 2)
-#define LVL_NUM_3 (12 * 2)
-#define LVL_NUM_4 (20 * 2)
-#define LVL_NUM_5 (1 * 2)
 
 extern const JE_char shapeFile[34]; /* [1..34] */
 

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -986,13 +986,6 @@ void JE_nextEpisode( void )
 
 	if (jumpBackToEpisode1)
 	{
-		// shareware version check
-		if (episodeNum == 1 &&
-			!isNetworkGame && !constantPlay)
-		{
-			// JE_loadOrderingInfo();
-		}
-
 		if (episodeNum > 2 &&
 			!constantPlay)
 		{

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -1026,7 +1026,6 @@ void JE_nextEpisode( void )
 	JE_showVGA();
 	fade_palette(colors, 15, 0, 255);
 
-	JE_wipeKey();
 	if (!constantPlay)
 	{
 		do
@@ -1877,9 +1876,6 @@ void JE_inGameHelp( void )
 
 	//tempScreenSeg = VGAScreenSeg;
 
-	JE_clearKeyboard();
-	JE_wipeKey();
-
 	JE_barShade(VGAScreen, 1, 1, 262, 182); /*Main Box*/
 	JE_barShade(VGAScreen, 3, 3, 260, 180);
 	JE_barShade(VGAScreen, 5, 5, 258, 178);
@@ -2684,7 +2680,6 @@ void JE_endLevelAni( void )
 	player[0].last_items = player[0].items;
 	strcpy(lastLevelName, levelName);
 
-	JE_wipeKey();
 	frameCountMax = 4;
 	textGlowFont = SMALL_FONT_SHAPES;
 

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -1381,7 +1381,6 @@ void JE_doInGameSetup( void )
 			reallyEndLevel = true;
 			playerEndLevel = true;
 		}
-		quitRequested = false;
 
 		keysactive[SDL_SCANCODE_ESCAPE] = false;
 

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -3619,7 +3619,7 @@ redo:
 				{
 					button[0] |= mouse_pressed[0];
 					button[1] |= mouse_pressed[1];
-					button[2] |= mouse_has_three_buttons ? mouse_pressed[2] : mouse_pressed[1];
+					button[2] |= mouse_pressed[2];
 
 					if (input_grab_enabled)
 					{

--- a/src/mainint.h
+++ b/src/mainint.h
@@ -46,7 +46,6 @@ void JE_gammaCorrect_func( JE_byte *col, JE_real r );
 void JE_gammaCorrect( Palette *colorBuffer, JE_byte gamma );
 JE_boolean JE_gammaCheck( void );
 /* void JE_textMenuWait( JE_word *waitTime, JE_boolean doGamma ); /!\ In setup.h */
-void JE_loadOrderingInfo( void );
 void JE_nextEpisode( void );
 void JE_helpSystem( JE_byte startTopic );
 void JE_doInGameSetup( void );

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -29,7 +29,6 @@ bool has_mouse = false;
 #else
 bool has_mouse = true;
 #endif
-bool mouse_has_three_buttons = true;
 
 bool mouseInactive = true;
 JE_byte mouseCursor;

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -33,7 +33,6 @@ enum
 };
 
 extern bool has_mouse;
-extern bool mouse_has_three_buttons;
 
 extern bool mouseInactive;
 extern JE_byte mouseCursor;

--- a/src/nortsong.c
+++ b/src/nortsong.c
@@ -32,9 +32,7 @@
 
 Uint32 target, target2;
 
-JE_boolean notYetLoadedSound = true;
-
-JE_word frameCount, frameCountMax;
+JE_word frameCountMax;
 
 JE_byte *digiFx[SAMPLE_COUNT] = { NULL }; /* [1..soundnum + 9] */
 JE_word fxSize[SAMPLE_COUNT]; /* [1..soundnum + 9] */
@@ -154,9 +152,6 @@ void JE_loadSndFile( const char *effects_sndfile, const char *voices_sndfile )
 	}
 
 	fclose(fi);
-
-	notYetLoadedSound = false;
-
 }
 
 void JE_playSampleNum( JE_byte samplenum )

--- a/src/nortsong.c
+++ b/src/nortsong.c
@@ -34,7 +34,7 @@ Uint32 target, target2;
 
 JE_boolean notYetLoadedSound = true;
 
-JE_word frameCount, frameCount2, frameCountMax;
+JE_word frameCount, frameCountMax;
 
 JE_byte *digiFx[SAMPLE_COUNT] = { NULL }; /* [1..soundnum + 9] */
 JE_word fxSize[SAMPLE_COUNT]; /* [1..soundnum + 9] */

--- a/src/nortsong.h
+++ b/src/nortsong.h
@@ -28,7 +28,7 @@
 
 extern Uint32 target, target2;
 
-extern JE_word frameCount, frameCount2, frameCountMax;
+extern JE_word frameCount, frameCountMax;
 
 extern JE_byte *digiFx[SAMPLE_COUNT];
 extern JE_word fxSize[SAMPLE_COUNT];

--- a/src/nortsong.h
+++ b/src/nortsong.h
@@ -28,7 +28,7 @@
 
 extern Uint32 target, target2;
 
-extern JE_word frameCount, frameCountMax;
+extern JE_word frameCountMax;
 
 extern JE_byte *digiFx[SAMPLE_COUNT];
 extern JE_word fxSize[SAMPLE_COUNT];

--- a/src/nortvars.c
+++ b/src/nortvars.c
@@ -80,9 +80,3 @@ void JE_barDrawShadow( SDL_Surface *surface, JE_word x, JE_word y, JE_word res, 
 		fill_rectangle_xy(surface, x,y, x+xsize, y+ysize, col+(12 / res * amt));
 	}
 }
-
-void JE_wipeKey( void )
-{
-	// /!\ Doesn't seems to affect anything.
-}
-

--- a/src/nortvars.h
+++ b/src/nortvars.h
@@ -29,7 +29,6 @@ JE_boolean JE_anyButton( void );
 
 void JE_dBar3( SDL_Surface *surface, JE_integer x,  JE_integer y,  JE_integer num,  JE_integer col );
 void JE_barDrawShadow( SDL_Surface *surface, JE_word x, JE_word y, JE_word res, JE_word col, JE_word amt, JE_word xsize, JE_word ysize );
-void JE_wipeKey( void );
 
 #endif /* NORTVARS_H */
 

--- a/src/nortvars.h
+++ b/src/nortvars.h
@@ -25,8 +25,6 @@
 
 extern JE_boolean inputDetected;
 
-JE_boolean JE_buttonPressed( void );
-
 JE_boolean JE_anyButton( void );
 
 void JE_dBar3( SDL_Surface *surface, JE_integer x,  JE_integer y,  JE_integer num,  JE_integer col );

--- a/src/sizebuf.c
+++ b/src/sizebuf.c
@@ -69,21 +69,7 @@ void SZ_Memset(sizebuf_t * sz, int value, size_t count)
 	memset(sz->data + sz->bufferPos, value, count);
 	sz->bufferPos += count;
 }
-/* Mimic memcpy.  Two versions, one for buffers, one for sizebuf objects.
- * Overload in C++. */
-void SZ_Memcpy(sizebuf_t * sz, const Uint8 * buf, size_t count)
-{
-	/* State checking */
-	if (sz->error || sz->bufferPos + count > sz->bufferLen)
-	{
-		sz->error = true;
-		return;
-	}
-
-	/* Memcpy & increment */
-	memcpy(sz->data + sz->bufferPos, buf, count);
-	sz->bufferPos += count;
-}
+/* Mimic memcpy. */
 void SZ_Memcpy2(sizebuf_t * sz, sizebuf_t * bf, size_t count)
 {
 	/* State checking */
@@ -131,49 +117,11 @@ void SZ_Seek(sizebuf_t * sz, long count, int mode)
 		sz->error = false;
 	}
 }
-const Uint8 * SZ_GetCurBufferPtr (sizebuf_t * sz)
-{
-	return(sz->data);
-}
 
 /* The code below makes use of pointer casts, similar to what is in efread.
  * It's not the ONLY way to write ints to a stream, but it's probably the
  * cleanest of the lot.  Better to have it here than littered all over the code.
  */
-void MSG_WriteByte(sizebuf_t * sz, unsigned int value)
-{
-	if (sz->error || sz->bufferPos + 1 > sz->bufferLen)
-	{
-		sz->error = true;
-		return;
-	}
-
-	sz->data[sz->bufferPos] = value;
-	sz->bufferPos++;
-}
-void MSG_WriteWord(sizebuf_t * sz, unsigned int value)
-{
-	if (sz->error || sz->bufferPos + 2 > sz->bufferLen)
-	{
-		sz->error = true;
-		return;
-	}
-
-	*((Uint16 *)(sz->data + sz->bufferPos)) = SDL_SwapLE16( ((Uint16)value) );
-	sz->bufferPos += 2;
-}
-void MSG_WriteDWord(sizebuf_t * sz, unsigned int value)
-{
-	if (sz->error || sz->bufferPos + 4 > sz->bufferLen)
-	{
-		sz->error = true;
-		return;
-	}
-
-	*((Uint32 *)(sz->data + sz->bufferPos)) = SDL_SwapLE32( ((Uint32)value) );
-	sz->bufferPos += 4;
-}
-
 unsigned int MSG_ReadByte(sizebuf_t * sz)
 {
 	unsigned int ret;
@@ -203,22 +151,6 @@ unsigned int MSG_ReadWord(sizebuf_t * sz)
 
 	ret = SDL_SwapLE16(*((Uint16 *)(sz->data + sz->bufferPos)));
 	sz->bufferPos += 2;
-
-	return(ret);
-}
-unsigned int MSG_ReadDWord(sizebuf_t * sz)
-{
-	unsigned int ret;
-
-
-	if (sz->error || sz->bufferPos + 4 > sz->bufferLen)
-	{
-		sz->error = true;
-		return(0);
-	}
-
-	ret = SDL_SwapLE32(*((Uint32 *)(sz->data + sz->bufferPos)));
-	sz->bufferPos += 4;
 
 	return(ret);
 }

--- a/src/sizebuf.h
+++ b/src/sizebuf.h
@@ -33,18 +33,10 @@ typedef struct sizebuf_s
 void SZ_Init    ( sizebuf_t *, Uint8 *, unsigned int ); /* C style constructor */
 bool SZ_Error   ( sizebuf_t * );
 void SZ_Memset  ( sizebuf_t *, int, size_t ); /* memset with a sizebuf */
-void SZ_Memcpy  ( sizebuf_t *, const Uint8 *, size_t ); /* memcpy with a normal buffer */
 void SZ_Memcpy2 ( sizebuf_t *, sizebuf_t *, size_t );   /* memcpy with a sizebuf */
 void SZ_Seek    ( sizebuf_t *, long, int ); /* fseek with a sizebuf. */
 
-const Uint8 * SZ_GetCurBufferPtr ( sizebuf_t * ); /* Mimic private member, const return */
-
-void MSG_WriteByte  ( sizebuf_t *, unsigned int );
-void MSG_WriteWord  ( sizebuf_t *, unsigned int );
-void MSG_WriteDWord ( sizebuf_t *, unsigned int );
-
 unsigned int MSG_ReadByte  ( sizebuf_t * );
 unsigned int MSG_ReadWord  ( sizebuf_t * );
-unsigned int MSG_ReadDWord ( sizebuf_t * );
 
 #endif

--- a/src/starlib.c
+++ b/src/starlib.c
@@ -69,8 +69,6 @@ void JE_starlib_main( void )
 	struct JE_StarType *stars;
 	Uint8 *surf;
 
-	JE_wackyCol();
-
 	grayB = false;
 
 	starlib_speed += speedChange;
@@ -319,11 +317,6 @@ void JE_starlib_main( void )
 	}
 
 	nspVarInc += nspVarVarInc;
-}
-
-void JE_wackyCol( void )
-{
-	/* YKS: Does nothing */
 }
 
 void JE_starlib_init( void )

--- a/src/starlib.h
+++ b/src/starlib.h
@@ -22,7 +22,6 @@
 #include "opentyr.h"
 
 void JE_starlib_main( void );
-void JE_wackyCol( void );
 void JE_starlib_init( void );
 void JE_resetValues( void );
 void JE_changeSetup( JE_byte setupType );

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -3896,8 +3896,6 @@ uint JE_makeEnemy( struct JE_SingleEnemyType *enemy, Uint16 eDatI, Sint16 unique
 		// Use shape table value from previous enemy that occupied the enemy slot. (Ex. APPROACH.)
 		fprintf(stderr, "warning: ignoring sprite from unloaded shape table %d\n", shapeTableI);
 
-	enemy->enemydatofs = &enemyDat[eDatI];
-
 	enemy->mapoffset = 0;
 
 	for (uint i = 0; i < 3; ++i)
@@ -3988,9 +3986,6 @@ uint JE_makeEnemy( struct JE_SingleEnemyType *enemy, Uint16 eDatI, Sint16 unique
 		enemy->eyrev = 0;
 	else
 		enemy->eyrev = enemyDat[eDatI].yrev;
-
-	enemy->exca = (enemy->xaccel > 0) ? 1 : -1;
-	enemy->eyca = (enemy->yaccel > 0) ? 1 : -1;
 
 	enemy->enemytype = eDatI;
 

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -150,7 +150,6 @@ void JE_starShowVGA( void )
 		JE_showVGA();
 	}
 
-	quitRequested = false;
 	skipStarShowVGA = false;
 }
 
@@ -845,7 +844,6 @@ start_level_first:
 	starActive = true;
 	enemyContinualDamage = false;
 	levelEnemyFrequency = 96;
-	quitRequested = false;
 
 	for (unsigned int i = 0; i < COUNTOF(boss_bar); i++)
 		boss_bar[i].link_num = 0;

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -644,8 +644,6 @@ start_level:
 	if (galagaMode)
 		twoPlayerMode = false;
 
-	JE_clearKeyboard();
-
 	free_sprite2s(&enemySpriteSheets[0]);
 	free_sprite2s(&enemySpriteSheets[1]);
 	free_sprite2s(&enemySpriteSheets[2]);
@@ -2678,7 +2676,6 @@ new_game:
 						while (s[0] != '#');
 						levelWarningLines--;
 
-						JE_wipeKey();
 						frameCountMax = 4;
 						if (!constantPlay)
 							JE_displayText();
@@ -2951,7 +2948,6 @@ new_game:
 						{
 							if (!ESCPressed)
 							{
-								JE_wipeKey();
 								warningCol = 14 * 16 + 5;
 								warningColChange = 1;
 								warningSoundDelay = 0;

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -2346,11 +2346,6 @@ draw_player_shot_loop_end:
 		explodeMove = 2;
 		stopBackgroundNum = 0;
 		stopBackgrounds = false;
-		if (waitToEndLevel)
-		{
-			endLevel = true;
-			levelEnd = 40;
-		}
 		if (allPlayersGone)
 		{
 			reallyEndLevel = true;

--- a/src/varz.c
+++ b/src/varz.c
@@ -180,7 +180,7 @@ JE_word levelEndFxWait;
 JE_shortint levelEndWarp;
 JE_boolean endLevel, reallyEndLevel, waitToEndLevel, playerEndLevel,
            normalBonusLevelCurrent, bonusLevelCurrent,
-           smallEnemyAdjust, readyToEndLevel, quitRequested;
+           smallEnemyAdjust, readyToEndLevel;
 
 JE_byte newPL[10]; /* [0..9] */ /*Eventsys event 75 parameter*/
 JE_word returnLoc;

--- a/src/varz.c
+++ b/src/varz.c
@@ -178,7 +178,7 @@ JE_word tempBackMove, explodeMove; /*Speed of background movement*/
 JE_byte levelEnd;
 JE_word levelEndFxWait;
 JE_shortint levelEndWarp;
-JE_boolean endLevel, reallyEndLevel, waitToEndLevel, playerEndLevel,
+JE_boolean endLevel, reallyEndLevel, playerEndLevel,
            normalBonusLevelCurrent, bonusLevelCurrent,
            smallEnemyAdjust, readyToEndLevel;
 

--- a/src/varz.h
+++ b/src/varz.h
@@ -52,10 +52,8 @@ enum
 
 struct JE_SingleEnemyType
 {
-	JE_byte     fillbyte;
 	JE_integer  ex, ey;     /* POSITION */
 	JE_shortint exc, eyc;   /* CURRENT SPEED */
-	JE_shortint exca, eyca; /* RANDOM ACCELERATION */
 	JE_shortint excc, eycc; /* FIXED ACCELERATION WAITTIME */
 	JE_shortint exccw, eyccw;
 	JE_byte     armorleft;
@@ -72,14 +70,12 @@ struct JE_SingleEnemyType
 	JE_shortint exrev, eyrev;
 	JE_integer  exccadd, eyccadd;
 	JE_byte     exccwmax, eyccwmax;
-	void       *enemydatofs;
 	JE_boolean  edamaged;
 	JE_word     enemytype;
 	JE_byte     animin;
 	JE_word     edgr;
 	JE_shortint edlevel;
 	JE_shortint edani;
-	JE_byte     fill1;
 	JE_byte     filter;
 	JE_integer  evalue;
 	JE_integer  fixedmovey;

--- a/src/varz.h
+++ b/src/varz.h
@@ -229,7 +229,7 @@ extern JE_word tempBackMove, explodeMove;
 extern JE_byte levelEnd;
 extern JE_word levelEndFxWait;
 extern JE_shortint levelEndWarp;
-extern JE_boolean endLevel, reallyEndLevel, waitToEndLevel, playerEndLevel, normalBonusLevelCurrent, bonusLevelCurrent, smallEnemyAdjust, readyToEndLevel;
+extern JE_boolean endLevel, reallyEndLevel, playerEndLevel, normalBonusLevelCurrent, bonusLevelCurrent, smallEnemyAdjust, readyToEndLevel;
 extern JE_byte newPL[10];
 extern JE_word returnLoc;
 extern JE_boolean returnActive;

--- a/src/varz.h
+++ b/src/varz.h
@@ -229,7 +229,7 @@ extern JE_word tempBackMove, explodeMove;
 extern JE_byte levelEnd;
 extern JE_word levelEndFxWait;
 extern JE_shortint levelEndWarp;
-extern JE_boolean endLevel, reallyEndLevel, waitToEndLevel, playerEndLevel, normalBonusLevelCurrent, bonusLevelCurrent, smallEnemyAdjust, readyToEndLevel, quitRequested;
+extern JE_boolean endLevel, reallyEndLevel, waitToEndLevel, playerEndLevel, normalBonusLevelCurrent, bonusLevelCurrent, smallEnemyAdjust, readyToEndLevel;
 extern JE_byte newPL[10];
 extern JE_word returnLoc;
 extern JE_boolean returnActive;


### PR DESCRIPTION
This is structured as a series of commits for easier reviewing.

* Remove unused declarations: `JE_loadOrderingInfo()`, `JE_buttonPressed()`.
  + And remove the "shareware version check", which has no side effects.
* Remove unused function `JE_drawFrame()`.
* Remove unused `sizebuf` functions: `SZ_Memcpy()`, `SZ_GetCurBufferPtr()`, `MSG_WriteByte()`, `MSG_WriteWord()`, `MSG_WriteDWord()`, `MSG_ReadDWord()`.
  + And update a comment now that `SZ_Memcpy()` is gone, leaving only `SZ_Memcpy2()`.
* Remove unused `config_file` functions: `config_find_sections()`, `config_get_or_set_string_option()`, `config_get_or_set_uint_option()`.
* Remove unused `fwrite` functions: `fwrite_s16_die()`, `fwrite_u32_die()`, `fwrite_s32_die()`.
* Remove no-op functions `JE_clearKeyboard()`, `JE_wipeKey()`, `JE_wackyCol()`.
* Remove unused macros: `foreach_option_value`, `UNIT_HEIGHT`, `NO_SHADE`, `ARMOR_NUM`, `ENGINE_NUM`, `LVL_NUM`, `LVL_NUM_2`, `LVL_NUM_3`, `LVL_NUM_4`, `LVL_NUM_5`.
  + The `LVL_NUM` family became unused after 0af1efb81d7d09235ca8d384eee0d8550efc1ff4.
* Remove unused variables `frameCount2`, `sound_init_state`.
* Remove dead variables `frameCount`, `notYetLoadedSound`, `quitRequested`.
  + These are written to, but never read.
* Remove never-assigned variable `waitToEndLevel`.
  + Static initialization means it's always `false`.
* Remove never-assigned variable `mouse_has_three_buttons`.
  + It's always `true`.
* Remove unused `ConfigBoolStyle`/`bool_values` entries.
  + `ZERO_ONE` and `FALSE_TRUE` were never used by the code. These enumerators aren't persisted anywhere, so there's no file compatibility concern, but we do need to re-number the remaining enumerators starting from `0`. Add a comment explaining why.
* Remove unused fields from `JE_SingleEnemyType`.
  + `fillbyte` and `fill1` were completely unused.
  + `exca`, `eyca`, and `enemydatofs` were dead.
  + As far as I can tell, the layout of this struct poses no compatibility concerns (I don't see it being directly read from files, and `JE_makeEnemy()` assigns each field).
  + On x64, this decreases the struct size from 152 to 144 bytes.
