### PR TITLE
Fix GCC warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ CPPFLAGS += -DNDEBUG
 CFLAGS ?= -pedantic \
           -Wall \
           -Wextra \
-          -Werror \
           -Wno-format-truncation \
           -Wno-missing-field-initializers \
           -O2
@@ -102,6 +101,7 @@ all : $(TARGET)
 
 .PHONY : debug
 debug : CPPFLAGS += -UNDEBUG
+debug : CFLAGS += -Werror
 debug : CFLAGS += -O0
 debug : CFLAGS += -g3
 debug : all

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ CPPFLAGS += -DNDEBUG
 CFLAGS ?= -pedantic \
           -Wall \
           -Wextra \
+          -Werror \
+          -Wno-format-truncation \
           -Wno-missing-field-initializers \
           -O2
 LDFLAGS ?=
@@ -100,7 +102,6 @@ all : $(TARGET)
 
 .PHONY : debug
 debug : CPPFLAGS += -UNDEBUG
-debug : CFLAGS += -Werror
 debug : CFLAGS += -O0
 debug : CFLAGS += -g3
 debug : all

--- a/src/episodes.c
+++ b/src/episodes.c
@@ -225,9 +225,9 @@ void JE_initEpisode( JE_byte newEpisode )
 	
 	episodeNum = newEpisode;
 	
-	sprintf(levelFile,    "tyrian%d.lvl",  episodeNum);
-	sprintf(cube_file,    "cubetxt%d.dat", episodeNum);
-	sprintf(episode_file, "levels%d.dat",  episodeNum);
+	snprintf(levelFile,    sizeof(levelFile),    "tyrian%d.lvl",  episodeNum);
+	snprintf(cube_file,    sizeof(cube_file),    "cubetxt%d.dat", episodeNum);
+	snprintf(episode_file, sizeof(episode_file), "levels%d.dat",  episodeNum);
 	
 	JE_analyzeLevel();
 	JE_loadItemDat();


### PR DESCRIPTION
This fixes warnings in the `continuous-integration/appveyor/linux` check. See [this example](https://ci.appveyor.com/project/carlreinke/opentyrian-linux/builds/42805405) of those warnings.

* Fix GCC `-Wformat-overflow` warnings.
  + By using `snprintf()`, which is already used elsewhere.
* Silence GCC `-Wformat-truncation` warnings.
  + This warned about code like `assignment_to_code()` in `joystick.c`:
    ```c
    static char name[7];
    // ...
    snprintf(name, sizeof(name), "BTN %d", assignment->num + 1);
    ```
