### PR TITLE
Fix build when WITH_NETWORK is false

### DIFF
--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -3192,6 +3192,7 @@ new_game:
 	/* End of find loop for LEVEL??.DAT */
 }
 
+#ifdef WITH_NETWORK
 void networkStartScreen( void )
 {
 	JE_loadPic(VGAScreen, 2, false);
@@ -3269,6 +3270,7 @@ void networkStartScreen( void )
 		SDL_Delay(16);
 	}
 }
+#endif /* WITH_NETWORK */
 
 bool titleScreen( void )
 {

--- a/src/tyrian2.h
+++ b/src/tyrian2.h
@@ -55,7 +55,9 @@ void JE_starShowVGA( void );
 
 void JE_main( void );
 void JE_loadMap( void );
+#ifdef WITH_NETWORK
 void networkStartScreen( void );
+#endif
 bool titleScreen( void );
 bool newGame( void );
 bool newSuperArcadeGame( unsigned int i );


### PR DESCRIPTION
`networkStartScreen` should only be compiled with WITH_NETWORK macro present since it uses SDL2_net.