### PR TITLE
reducing input latency by 1+ frames

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -135,7 +135,7 @@ void mouseGetRelativePosition(Sint32 *const out_x, Sint32 *const out_y)
 	mouseWindowYRelative = 0;
 }
 
-void service_SDL_events(JE_boolean clear_new)
+static void service_SDL_events_ex(JE_boolean clear_new, JE_boolean drain_all)
 {
 	SDL_Event ev;
 
@@ -187,12 +187,16 @@ void service_SDL_events(JE_boolean clear_new)
 				keydown = true;
 
 				mouseInactive = true;
-				return;
+				if (!drain_all)
+					return;
+				break;
 
 			case SDL_KEYUP:
 				keysactive[ev.key.keysym.scancode] = 0;
 				keydown = false;
-				return;
+				if (!drain_all)
+					return;
+				break;
 
 			case SDL_MOUSEMOTION:
 				mouse_x = ev.motion.x;
@@ -256,6 +260,16 @@ void service_SDL_events(JE_boolean clear_new)
 				break;
 		}
 	}
+}
+
+void service_SDL_events(JE_boolean clear_new)
+{
+	service_SDL_events_ex(clear_new, false);
+}
+
+void service_SDL_events_full(JE_boolean clear_new)
+{
+	service_SDL_events_ex(clear_new, true);
 }
 
 void JE_clearKeyboard(void)

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -125,8 +125,6 @@ JE_word JE_mousePosition(JE_word *mouseX, JE_word *mouseY)
 
 void mouseGetRelativePosition(Sint32 *const out_x, Sint32 *const out_y)
 {
-	service_SDL_events(false);
-
 	scaleWindowDistanceToScreen(&mouseWindowXRelative, &mouseWindowYRelative);
 	*out_x = mouseWindowXRelative;
 	*out_y = mouseWindowYRelative;

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -51,6 +51,7 @@ JE_word JE_mousePosition(JE_word *mouseX, JE_word *mouseY);
 void mouseGetRelativePosition(Sint32 *out_x, Sint32 *out_y);
 
 void service_SDL_events(JE_boolean clear_new);
+void service_SDL_events_full(JE_boolean clear_new);
 
 void sleep_game(void);
 

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -3603,8 +3603,6 @@ redo:
 					}
 				}
 
-				service_SDL_events(false);
-
 				/* mouse input */
 				if ((inputDevice == 0 || inputDevice == 2) && has_mouse)
 				{

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -3578,8 +3578,6 @@ redo:
 					int j_max = inputDevice == 0 ? joysticks : inputDevice - 3 + 1;
 					for (; j < j_max; j++)
 					{
-						poll_joystick(j);
-
 						if (joystick[j].analog)
 						{
 							mouseXC += joystick_axis_reduce(j, joystick[j].x);

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -87,12 +87,6 @@ void JE_starShowVGA(void)
 		src = game_screen->pixels;
 		src += 24;
 
-		if (smoothScroll != 0 /*&& thisPlayerNum != 2*/)
-		{
-			wait_delay();
-			setDelay(frameCountMax);
-		}
-
 		if (starShowVGASpecialCode == 1)
 		{
 			src += game_screen->pitch * 183;
@@ -1079,6 +1073,15 @@ start_level_first:
 	BKwrap3 = BKwrap3to = &megaData3.mainmap[1][0];
 
 level_loop:
+
+	/* Frame pacing — moved from JE_starShowVGA so that wait_delay sleeps
+	   at the top of the frame rather than just before present.  This
+	   reduces input-to-display latency from ~1 frame to near zero. */
+	if (smoothScroll != 0 && !playerEndLevel && !skipStarShowVGA)
+	{
+		wait_delay();
+		setDelay(frameCountMax);
+	}
 
 	//tempScreenSeg = game_screen; /* side-effect of game_screen */
 

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -1083,6 +1083,12 @@ level_loop:
 		setDelay(frameCountMax);
 	}
 
+	/* Drain all pending input at the top of the frame so that every
+	   subsystem within this iteration sees a consistent snapshot of
+	   keyboard, mouse and joystick state. */
+	push_joysticks_as_keyboard();
+	service_SDL_events_full(true);
+
 	//tempScreenSeg = game_screen; /* side-effect of game_screen */
 
 	if (isNetworkGame)

--- a/src/tyrian2.c
+++ b/src/tyrian2.c
@@ -2181,8 +2181,6 @@ draw_player_shot_loop_end:
 
 				if (!play_demo)
 				{
-					push_joysticks_as_keyboard();
-					service_SDL_events(true);
 					if ((newkey || button[0] || button[1] || button[2]) || newmouse)
 					{
 						reallyEndLevel = true;
@@ -2197,9 +2195,6 @@ draw_player_shot_loop_end:
 
 	if (play_demo) // input kills demo
 	{
-		push_joysticks_as_keyboard();
-		service_SDL_events(false);
-
 		if (newkey || newmouse)
 		{
 			reallyEndLevel = true;
@@ -2209,8 +2204,6 @@ draw_player_shot_loop_end:
 	}
 	else // input handling for pausing, menu, cheats
 	{
-		service_SDL_events(false);
-
 		if (newkey)
 		{
 			skipStarShowVGA = false;


### PR DESCRIPTION
These commits reduce input latency by:
- Moving the frame pacing delay outside the sample-input/sim+render/present-frame critical path (always saves 1 frame or ~28 ms at Normal game speed).
- Allowing draining of multiple keypresses in a single frame when not in menus (saves 1 frame per additional _simultaneously_ pressed or released key).

I've playtested these with both mouse and keyboard and checked for correct functionality of menu functionality etc. and subjective perceptibility of the lag reduction, but it would be good to have independent confirmation of:
- Joystick handling in both menus and gameplay
- Two-player gameplay
- SF codes with joystick and mouse (shouldn't have been affected due to their reliance on ship position instead of raw inputs, but I'm not good enough with the twiddles on a mouse to verify myself)

Aside from the lag reduction, these changes should make it marginally easier for people to follow JE_main()'s operation, which is now effectively deterministic within level_loop for gameplay state, excluding cheat and game speed mutation in the menu.