### PR TITLE
Fix wrong evolution of boundary checks

### DIFF
--- a/src/destruct.c
+++ b/src/destruct.c
@@ -1327,7 +1327,7 @@ static void JE_eSound(unsigned int sound)
 
 static void JE_superPixel(unsigned int tempPosX, unsigned int tempPosY)
 {
-	const unsigned int starPattern[5][5] =
+	static const unsigned int starPattern[5][5] =
 	{
 		{   0,   0, 246,   0,   0 },
 		{   0, 247, 249, 247,   0 },
@@ -1335,7 +1335,7 @@ static void JE_superPixel(unsigned int tempPosX, unsigned int tempPosY)
 		{   0, 247, 249, 247,   0 },
 		{   0,   0, 246,   0,   0 }
 	};
-	const unsigned int starIntensity[5][5] =
+	static const unsigned int starIntensity[5][5] =
 	{
 		{   0,   0,   1,   0,   0 },
 		{   0,   1,   2,   1,   0 },

--- a/src/mainint.c
+++ b/src/mainint.c
@@ -2153,7 +2153,7 @@ void JE_highScoreCheck(void)
 // increases game difficulty based on player's total score / total of players' scores
 void adjust_difficulty(void)
 {
-	const float score_multiplier[10] =
+	static const float score_multiplier[10] =
 	{
 		0,     // Wimp  (doesn't exist)
 		0.4f,  // Easy

--- a/src/vga256d.c
+++ b/src/vga256d.c
@@ -34,7 +34,7 @@
 void JE_pix(SDL_Surface *surface, int x, int y, JE_byte c)
 {
 	/* Bad things happen if we don't clip */
-	if (x <  surface->pitch && y <  surface->h)
+	if ((unsigned int)x < (unsigned int)surface->pitch && (unsigned int)y < (unsigned int)surface->h)
 	{
 		Uint8 *vga = surface->pixels;
 		vga[y * surface->pitch + x] = c;
@@ -53,8 +53,8 @@ void JE_pix3(SDL_Surface *surface, int x, int y, JE_byte c)
 
 void JE_rectangle(SDL_Surface *surface, int a, int b, int c, int d, int e) /* x1, y1, x2, y2, color */
 {
-	if (a < surface->pitch && b < surface->h &&
-	    c < surface->pitch && d < surface->h)
+	if ((unsigned int)a < (unsigned int)surface->pitch && (unsigned int)b < (unsigned int)surface->h &&
+	    (unsigned int)c < (unsigned int)surface->pitch && (unsigned int)d < (unsigned int)surface->h)
 	{
 		Uint8 *vga = surface->pixels;
 		int i;
@@ -91,8 +91,8 @@ void fill_rectangle_xy(SDL_Surface *surface, int x, int y, int x2, int y2, Uint8
 
 void JE_barShade(SDL_Surface *surface, int a, int b, int c, int d) /* x1, y1, x2, y2 */
 {
-	if (a < surface->pitch && b < surface->h &&
-	    c < surface->pitch && d < surface->h)
+	if ((unsigned int)a < (unsigned int)surface->pitch && (unsigned int)b < (unsigned int)surface->h &&
+	    (unsigned int)c < (unsigned int)surface->pitch && (unsigned int)d < (unsigned int)surface->h)
 	{
 		Uint8 *vga = surface->pixels;
 		int i, j, width;
@@ -115,8 +115,8 @@ void JE_barShade(SDL_Surface *surface, int a, int b, int c, int d) /* x1, y1, x2
 
 void JE_barBright(SDL_Surface *surface, int a, int b, int c, int d) /* x1, y1, x2, y2 */
 {
-	if (a < surface->pitch && b < surface->h &&
-	    c < surface->pitch && d < surface->h)
+	if ((unsigned int)a < (unsigned int)surface->pitch && (unsigned int)b < (unsigned int)surface->h &&
+	    (unsigned int)c < (unsigned int)surface->pitch && (unsigned int)d < (unsigned int)surface->h)
 	{
 		Uint8 *vga = surface->pixels;
 		int i, j, width;


### PR DESCRIPTION
..and some statics to avoid reinit on each call

Originally, all the functions in `vga256d` used `JE_word`, which was `unsigned short`.
This means that all these functions implicitly checked both against width and height, BUT also against 0.
This PR adds casts to` unsigned int`, so making these functions work the same again.

In theory, the missing implicit `< 0` could lead to an out of bounds access.