### PR TITLE
CI and self-contained release builds for Linux, macOS and Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,9 +59,14 @@ jobs:
         run: ./make_linux.sh
       - name: Package (binary + game data)
         run: |
-          mkdir -p dist/opentyrian
+          mkdir -p dist/opentyrian/licenses
           cp opentyrian dist/opentyrian/
           cp -r data dist/opentyrian/data
+          cp COPYING dist/opentyrian/
+          cp doc/tyrian-data-license.txt dist/opentyrian/licenses/tyrian-data.txt
+          # SDL2 and SDL2_net are linked in statically, so their licences ship too
+          cp build/sdl/share/licenses/SDL2.txt dist/opentyrian/licenses/
+          cp build/sdl/share/licenses/SDL2_net.txt dist/opentyrian/licenses/
           tar -czf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C dist opentyrian
       - name: Extract the package
         run: mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
           - { runner: ubuntu-22.04,     arch: x86_64 }
           - { runner: ubuntu-22.04-arm, arch: arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # git describe --tags for the version string
       - name: Install dependencies
@@ -46,12 +46,12 @@ jobs:
       - name: Smoke test
         run: ./opentyrian --help
       - name: Cache game data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: data
           key: tyrian21-data-v1
       - name: Cache static SDL2 build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: build/sdl
           key: sdl2-static-${{ matrix.arch }}-${{ hashFiles('make_linux.sh') }}
@@ -70,7 +70,7 @@ jobs:
         run: |
           mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest
           docker run --rm -v "$PWD/pkgtest:/pkg:ro" -w / debian:bookworm-slim /pkg/opentyrian/opentyrian --help
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: opentyrian-linux-${{ matrix.arch }}
           path: opentyrian-linux-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,9 +42,9 @@ jobs:
             libgles2-mesa-dev libgbm-dev libdrm-dev libdbus-1-dev libudev-dev \
             wayland-protocols libpipewire-0.3-dev
       - name: Compile check (debug, -Werror, distro SDL2)
-        run: |
-          make -j"$(nproc)" debug
-          ./opentyrian --help
+        run: make -j"$(nproc)" debug
+      - name: Smoke test
+        run: ./opentyrian --help
       - name: Cache game data
         uses: actions/cache@v4
         with:
@@ -62,27 +62,12 @@ jobs:
           mkdir -p dist/opentyrian
           cp opentyrian dist/opentyrian/
           cp -r data dist/opentyrian/data
-          cat > dist/opentyrian/README.txt <<'EOF'
-          OpenTyrian - self-contained Linux build
-
-          Run ./opentyrian from this directory, or from anywhere: it finds the
-          data directory next to the executable.  SDL2 is linked in statically,
-          so nothing needs to be installed.
-
-          Config and saves live in ~/.config/opentyrian.
-          EOF
           tar -czf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C dist opentyrian
       - name: Verify the package is self-contained
-        # Two checks.  First, the only shared libraries the binary asks for
-        # are the ones every Linux has.  Second - the real test - the package
-        # runs in a bare Debian container with no SDL, no libdecor, nothing
-        # installed.  The runner itself proves nothing here: it has all of
-        # those, and a missing dependency would be silently satisfied.
+        # In a bare Debian container: no SDL, no libdecor, nothing installed.
+        # The runner itself proves nothing here - it has all of those, and a
+        # missing dependency would be silently satisfied.
         run: |
-          ldd opentyrian
-          if ldd opentyrian | grep -Ev 'linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so|libgcc_s\.so'; then
-            echo "ERROR: unexpected shared library dependency above" >&2; exit 1
-          fi
           mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest
           docker run --rm -v "$PWD/pkgtest:/pkg:ro" -w / debian:bookworm-slim /pkg/opentyrian/opentyrian --help
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,96 @@
+name: Linux
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write        # needed to attach assets on release events
+
+jobs:
+  build:
+    name: Linux (${{ matrix.arch }})
+    # 22.04 on purpose: the binary needs a glibc no newer than the one it was
+    # built against, so building on the oldest supported runner is what lets
+    # it run on more machines.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false     # one arch failing must not cancel the other
+      matrix:
+        include:
+          - { runner: ubuntu-22.04,     arch: x86_64 }
+          - { runner: ubuntu-22.04-arm, arch: arm64 }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # git describe --tags for the version string
+      - name: Install dependencies
+        # The distro libsdl2-dev is only for the -Werror compile check.  The
+        # release links a static SDL2 built from source (make_linux.sh), so
+        # the -dev packages after it are HEADERS for SDL's dlopen'ed backends
+        # - nothing from them is linked into the binary.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake pkg-config curl unzip libsdl2-dev libsdl2-net-dev \
+            libasound2-dev libpulse-dev libx11-dev libxext-dev libxrandr-dev \
+            libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
+            libxkbcommon-dev libdecor-0-dev libegl1-mesa-dev libgl1-mesa-dev \
+            libgles2-mesa-dev libgbm-dev libdrm-dev libdbus-1-dev libudev-dev \
+            wayland-protocols libpipewire-0.3-dev
+      - name: Compile check (debug, -Werror, distro SDL2)
+        run: |
+          make -j"$(nproc)" debug
+          ./opentyrian --help
+      - name: Cache game data
+        uses: actions/cache@v4
+        with:
+          path: data
+          key: tyrian21-data-v1
+      - name: Cache static SDL2 build
+        uses: actions/cache@v4
+        with:
+          path: build/sdl
+          key: sdl2-static-${{ matrix.arch }}-${{ hashFiles('make_linux.sh') }}
+      - name: Build (make_linux.sh, static SDL2)
+        run: ./make_linux.sh
+      - name: Package (binary + game data)
+        run: |
+          mkdir -p dist/opentyrian
+          cp opentyrian dist/opentyrian/
+          cp -r data dist/opentyrian/data
+          cat > dist/opentyrian/README.txt <<'EOF'
+          OpenTyrian - self-contained Linux build
+
+          Run ./opentyrian from this directory, or from anywhere: it finds the
+          data directory next to the executable.  SDL2 is linked in statically,
+          so nothing needs to be installed.
+
+          Config and saves live in ~/.config/opentyrian.
+          EOF
+          tar -czf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C dist opentyrian
+      - name: Verify the package is self-contained
+        # Two checks.  First, the only shared libraries the binary asks for
+        # are the ones every Linux has.  Second - the real test - the package
+        # runs in a bare Debian container with no SDL, no libdecor, nothing
+        # installed.  The runner itself proves nothing here: it has all of
+        # those, and a missing dependency would be silently satisfied.
+        run: |
+          ldd opentyrian
+          if ldd opentyrian | grep -Ev 'linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so|libgcc_s\.so'; then
+            echo "ERROR: unexpected shared library dependency above" >&2; exit 1
+          fi
+          mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest
+          docker run --rm -v "$PWD/pkgtest:/pkg:ro" -w / debian:bookworm-slim /pkg/opentyrian/opentyrian --help
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opentyrian-linux-${{ matrix.arch }}
+          path: opentyrian-linux-${{ matrix.arch }}.tar.gz
+      - name: Attach to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "opentyrian-linux-${{ matrix.arch }}.tar.gz" --clobber

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,13 +63,13 @@ jobs:
           cp opentyrian dist/opentyrian/
           cp -r data dist/opentyrian/data
           tar -czf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C dist opentyrian
+      - name: Extract the package
+        run: mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest
       - name: Verify the package is self-contained
         # In a bare Debian container: no SDL, no libdecor, nothing installed.
         # The runner itself proves nothing here - it has all of those, and a
         # missing dependency would be silently satisfied.
-        run: |
-          mkdir -p pkgtest && tar -xzf "opentyrian-linux-${{ matrix.arch }}.tar.gz" -C pkgtest
-          docker run --rm -v "$PWD/pkgtest:/pkg:ro" -w / debian:bookworm-slim /pkg/opentyrian/opentyrian --help
+        run: docker run --rm -v "$PWD/pkgtest:/pkg:ro" -w / debian:bookworm-slim /pkg/opentyrian/opentyrian --help
       - uses: actions/upload-artifact@v7
         with:
           name: opentyrian-linux-${{ matrix.arch }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Install build dependencies
         run: brew install pkgconf sdl2 sdl2_net
       - name: Compile check (debug, -Werror, Homebrew SDL2)
-        run: |
-          make -j"$(sysctl -n hw.ncpu)" debug
-          ./opentyrian --help
+        run: make -j"$(sysctl -n hw.ncpu)" debug
+      - name: Smoke test
+        run: ./opentyrian --help
       - name: Cache game data
         uses: actions/cache@v6
         with:
@@ -38,7 +38,8 @@ jobs:
           test -d build/OpenTyrian.app/Contents/Frameworks/SDL2.framework
           # the binary must not reference Homebrew - only the bundled framework
           if otool -L build/OpenTyrian.app/Contents/MacOS/opentyrian | grep -q /opt/homebrew; then exit 1; fi
-          build/OpenTyrian.app/Contents/MacOS/opentyrian --help
+      - name: Smoke test the bundle
+        run: build/OpenTyrian.app/Contents/MacOS/opentyrian --help
       - name: Zip app (preserving symlinks)
         run: cd build && zip -r -y opentyrian-macos-universal.zip OpenTyrian.app
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,52 @@
+name: macOS
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write        # needed to attach assets on release events
+
+jobs:
+  build:
+    name: macOS (universal .app)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # git describe --tags for the version string
+      - name: Install build dependencies
+        run: brew install pkgconf sdl2 sdl2_net
+      - name: Compile check (debug, -Werror, Homebrew SDL2)
+        run: |
+          make -j"$(sysctl -n hw.ncpu)" debug
+          ./opentyrian --help
+      - name: Cache game data
+        uses: actions/cache@v4
+        with:
+          path: data
+          key: tyrian21-data-v1
+      - name: Build OpenTyrian.app (universal, bundled SDL2 + game data)
+        run: ./make_mac.sh
+      - name: Verify the bundle
+        run: |
+          lipo -archs build/OpenTyrian.app/Contents/MacOS/opentyrian | grep -q "x86_64 arm64"
+          test -f build/OpenTyrian.app/Contents/Resources/data/tyrian1.lvl
+          test -d build/OpenTyrian.app/Contents/Frameworks/SDL2.framework
+          # the binary must not reference Homebrew - only the bundled framework
+          if otool -L build/OpenTyrian.app/Contents/MacOS/opentyrian | grep -q /opt/homebrew; then exit 1; fi
+          build/OpenTyrian.app/Contents/MacOS/opentyrian --help
+      - name: Zip app (preserving symlinks)
+        run: cd build && zip -r -y opentyrian-macos-universal.zip OpenTyrian.app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opentyrian-macos-universal
+          path: build/opentyrian-macos-universal.zip
+      - name: Attach to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" build/opentyrian-macos-universal.zip --clobber

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
           path: data
           key: tyrian21-data-v1
       - name: Build OpenTyrian.app (universal, bundled SDL2 + game data)
-        run: ./make_mac.sh
+        run: ./make_macos.sh
       - name: Verify the bundle
         run: |
           lipo -archs build/OpenTyrian.app/Contents/MacOS/opentyrian | grep -q "x86_64 arm64"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
     name: macOS (universal .app)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # git describe --tags for the version string
       - name: Install build dependencies
@@ -25,7 +25,7 @@ jobs:
           make -j"$(sysctl -n hw.ncpu)" debug
           ./opentyrian --help
       - name: Cache game data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: data
           key: tyrian21-data-v1
@@ -41,7 +41,7 @@ jobs:
           build/OpenTyrian.app/Contents/MacOS/opentyrian --help
       - name: Zip app (preserving symlinks)
         run: cd build && zip -r -y opentyrian-macos-universal.zip OpenTyrian.app
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: opentyrian-macos-universal
           path: build/opentyrian-macos-universal.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,9 +39,9 @@ jobs:
             ${{ matrix.prefix }}-SDL2
             ${{ matrix.prefix }}-SDL2_net
       - name: Compile check (debug, -Werror)
-        run: |
-          make -j"$(nproc)" debug
-          ./opentyrian.exe --help
+        run: make -j"$(nproc)" debug
+      - name: Smoke test
+        run: ./opentyrian.exe --help
       - name: Cache game data
         uses: actions/cache@v6
         with:
@@ -63,10 +63,10 @@ jobs:
           ldd opentyrian.exe | grep -iv "system32\|/c/windows" | awk '{print $3}' | sort -u | xargs -I{} cp {} dist/opentyrian/
           cp -r data dist/opentyrian/data
           cd dist && zip -r "../opentyrian-windows-${{ matrix.arch }}.zip" opentyrian
+      - name: Extract the package
+        run: mkdir -p /tmp/pkgtest && unzip -q "opentyrian-windows-${{ matrix.arch }}.zip" -d /tmp/pkgtest
       - name: Verify the package runs from a clean directory
-        run: |
-          mkdir -p /tmp/pkgtest && unzip -q "opentyrian-windows-${{ matrix.arch }}.zip" -d /tmp/pkgtest
-          cd / && /tmp/pkgtest/opentyrian/opentyrian.exe --help
+        run: cd / && /tmp/pkgtest/opentyrian/opentyrian.exe --help
       - uses: actions/upload-artifact@v7
         with:
           name: opentyrian-windows-${{ matrix.arch }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,11 +57,19 @@ jobs:
         run: ./opentyrian.exe --help
       - name: Package (exe + DLLs + game data)
         run: |
-          mkdir -p dist/opentyrian
+          mkdir -p dist/opentyrian/licenses
           cp opentyrian.exe dist/opentyrian/
           # bundle every non-system DLL the exe needs (SDL2, SDL2_net, compiler runtime)
           ldd opentyrian.exe | grep -iv "system32\|/c/windows" | awk '{print $3}' | sort -u | xargs -I{} cp {} dist/opentyrian/
           cp -r data dist/opentyrian/data
+          cp COPYING dist/opentyrian/COPYING.txt
+          cp doc/tyrian-data-license.txt dist/opentyrian/licenses/tyrian-data.txt
+          for pkg in SDL2 SDL2_net; do
+            lic=$(find "$MINGW_PREFIX/share/licenses/$pkg" "$MINGW_PREFIX/share/doc/$pkg" \
+                       -maxdepth 1 -type f \( -iname 'license*' -o -iname 'copying*' \) 2>/dev/null | head -1)
+            if [ -z "$lic" ]; then echo "ERROR: no licence file found for $pkg" >&2; exit 1; fi
+            cp "$lic" "dist/opentyrian/licenses/$pkg.txt"
+          done
           cd dist && zip -r "../opentyrian-windows-${{ matrix.arch }}.zip" opentyrian
       - name: Extract the package
         run: mkdir -p /tmp/pkgtest && unzip -q "opentyrian-windows-${{ matrix.arch }}.zip" -d /tmp/pkgtest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # git describe --tags for the version string
       - uses: msys2/setup-msys2@v2
@@ -43,7 +43,7 @@ jobs:
           make -j"$(nproc)" debug
           ./opentyrian.exe --help
       - name: Cache game data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: data
           key: tyrian21-data-v1
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir -p /tmp/pkgtest && unzip -q "opentyrian-windows-${{ matrix.arch }}.zip" -d /tmp/pkgtest
           cd / && /tmp/pkgtest/opentyrian/opentyrian.exe --help
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: opentyrian-windows-${{ matrix.arch }}
           path: opentyrian-windows-${{ matrix.arch }}.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,10 +65,7 @@ jobs:
           cp COPYING dist/opentyrian/COPYING.txt
           cp doc/tyrian-data-license.txt dist/opentyrian/licenses/tyrian-data.txt
           for pkg in SDL2 SDL2_net; do
-            lic=$(find "$MINGW_PREFIX/share/licenses/$pkg" "$MINGW_PREFIX/share/doc/$pkg" \
-                       -maxdepth 1 -type f \( -iname 'license*' -o -iname 'copying*' \) 2>/dev/null | head -1)
-            if [ -z "$lic" ]; then echo "ERROR: no licence file found for $pkg" >&2; exit 1; fi
-            cp "$lic" "dist/opentyrian/licenses/$pkg.txt"
+            cp "$MINGW_PREFIX/share/licenses/$pkg/LICENSE.txt" "dist/opentyrian/licenses/$pkg.txt"
           done
           cd dist && zip -r "../opentyrian-windows-${{ matrix.arch }}.zip" opentyrian
       - name: Extract the package

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,79 @@
+name: Windows
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write        # needed to attach assets on release events
+
+jobs:
+  build:
+    name: Windows (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false     # one arch failing must not cancel the other
+      matrix:
+        include:
+          - { runner: windows-latest, arch: x86_64, msystem: UCRT64,     prefix: mingw-w64-ucrt-x86_64 }
+          - { runner: windows-11-arm, arch: arm64,  msystem: CLANGARM64, prefix: mingw-w64-clang-aarch64 }
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # git describe --tags for the version string
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          # no `update:` — the pinned base install is fine for CI and much
+          # faster; the action's built-in cache (default on) does the rest
+          install: >-
+            make git curl unzip zip
+            ${{ matrix.prefix }}-cc
+            ${{ matrix.prefix }}-pkgconf
+            ${{ matrix.prefix }}-SDL2
+            ${{ matrix.prefix }}-SDL2_net
+      - name: Compile check (debug, -Werror)
+        run: |
+          make -j"$(nproc)" debug
+          ./opentyrian.exe --help
+      - name: Cache game data
+        uses: actions/cache@v4
+        with:
+          path: data
+          key: tyrian21-data-v1
+      - name: Fetch game data
+        run: ./get_data.sh data
+      - name: Build (release)
+        run: |
+          make clean
+          make -j"$(nproc)"
+      - name: Smoke test
+        run: ./opentyrian.exe --help
+      - name: Package (exe + DLLs + game data)
+        run: |
+          mkdir -p dist/opentyrian
+          cp opentyrian.exe dist/opentyrian/
+          # bundle every non-system DLL the exe needs (SDL2, SDL2_net, compiler runtime)
+          ldd opentyrian.exe | grep -iv "system32\|/c/windows" | awk '{print $3}' | sort -u | xargs -I{} cp {} dist/opentyrian/
+          cp -r data dist/opentyrian/data
+          cd dist && zip -r "../opentyrian-windows-${{ matrix.arch }}.zip" opentyrian
+      - name: Verify the package runs from a clean directory
+        run: |
+          mkdir -p /tmp/pkgtest && unzip -q "opentyrian-windows-${{ matrix.arch }}.zip" -d /tmp/pkgtest
+          cd / && /tmp/pkgtest/opentyrian/opentyrian.exe --help
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opentyrian-windows-${{ matrix.arch }}
+          path: opentyrian-windows-${{ matrix.arch }}.zip
+      - name: Attach to release
+        if: github.event_name == 'release'
+        shell: bash          # runner's own bash — gh isn't on the MSYS2 PATH
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "opentyrian-windows-${{ matrix.arch }}.zip" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ tyrian.sav
 # Doxygen output
 /doc/doxygen/
 
-# Release build scripts output (make_mac.sh, make_linux.sh)
+# Release build scripts output (make_macos.sh, make_linux.sh)
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tyrian.sav
 
 # Doxygen output
 /doc/doxygen/
+
+# Release build scripts output (make_mac.sh, make_linux.sh)
+/build/

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SHELL = /bin/sh
 CC ?= gcc
 INSTALL ?= install
 PKG_CONFIG ?= pkg-config
+WINDRES ?= windres
 
 VCS_IDREV ?= (git describe --tags || git rev-parse --short HEAD)
 
@@ -50,7 +51,6 @@ RES :=
 ifeq ($(PLATFORM), WIN32)
     TARGET := opentyrian.exe
     # The icon, from the same resource script the Visual Studio build uses.
-    WINDRES ?= windres
     RES := obj/resources.o
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,12 @@ gamesdir ?= $(datadir)/games
 ###
 
 TARGET := opentyrian
+RES :=
 ifeq ($(PLATFORM), WIN32)
     TARGET := opentyrian.exe
+    # The icon, from the same resource script the Visual Studio build uses.
+    WINDRES ?= windres
+    RES := obj/resources.o
 endif
 
 SRCS := $(wildcard src/*.c)
@@ -166,9 +170,10 @@ uninstall :
 clean :
 	rm -f $(OBJS)
 	rm -f $(DEPS)
+	rm -f $(RES)
 	rm -f $(TARGET)
 
-$(TARGET) : $(OBJS)
+$(TARGET) : $(OBJS) $(RES)
 	$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $^ $(ALL_LDLIBS)
 
 -include $(DEPS)
@@ -176,3 +181,7 @@ $(TARGET) : $(OBJS)
 obj/%.o : src/%.c
 	@mkdir -p "$(dir $@)"
 	$(CC) $(ALL_CPPFLAGS) $(ALL_CFLAGS) -c -o $@ $<
+
+obj/resources.o : visualc/resources.rc visualc/tyrian.ico
+	@mkdir -p "$(dir $@)"
+	$(WINDRES) --include-dir visualc -i $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ else
     TYRIAN_DIR = $(gamesdir)/tyrian
 endif
 
-WITH_NETWORK := true
+# true, false, or auto (true if pkg-config can find SDL2_net)
+WITH_NETWORK := auto
 
 ################################################################################
 
@@ -45,12 +46,24 @@ gamesdir ?= $(datadir)/games
 ###
 
 TARGET := opentyrian
+ifeq ($(PLATFORM), WIN32)
+    TARGET := opentyrian.exe
+endif
 
 SRCS := $(wildcard src/*.c)
 OBJS := $(SRCS:src/%.c=obj/%.o)
 DEPS := $(SRCS:src/%.c=obj/%.d)
 
 ###
+
+ifeq ($(WITH_NETWORK), auto)
+    ifeq ($(shell $(PKG_CONFIG) --exists SDL2_net 2>/dev/null && echo true), true)
+        WITH_NETWORK := true
+    else
+        WITH_NETWORK := false
+        $(info SDL2_net not found; building without network support)
+    endif
+endif
 
 ifeq ($(WITH_NETWORK), true)
     EXTRA_CPPFLAGS += -DWITH_NETWORK
@@ -62,12 +75,17 @@ ifneq ($(OPENTYRIAN_VERSION), )
     EXTRA_CPPFLAGS += -DOPENTYRIAN_VERSION='"$(OPENTYRIAN_VERSION)"'
 endif
 
+# -Wno-format-truncation only exists in GCC; Clang rejects it under -Werror
+ifeq ($(findstring clang, $(shell $(CC) --version 2>/dev/null)), )
+    WNO_FORMAT_TRUNCATION := -Wno-format-truncation
+endif
+
 CPPFLAGS ?= -MMD
 CPPFLAGS += -DNDEBUG
 CFLAGS ?= -pedantic \
           -Wall \
           -Wextra \
-          -Wno-format-truncation \
+          $(WNO_FORMAT_TRUNCATION) \
           -Wno-missing-field-initializers \
           -O2
 LDFLAGS ?=

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ searched in order:
    for the macOS app)
 3. the system directory the build was configured with
    (`/usr/local/share/games/tyrian` by default; `C:\TYRIAN` on Windows)
-4. a `data` directory in the current working directory
 
 `./get_data.sh [dir]` downloads and extracts them for you.  Filenames in the
 archive may be uppercase; the script lowercases them, as does
@@ -73,7 +72,7 @@ A Visual Studio solution is in `visualc/`.
 
 The self-contained release builds are produced by the same scripts CI uses:
 
-    ./make_mac.sh      # universal OpenTyrian.app in build/, SDL2.framework bundled
+    ./make_macos.sh      # universal OpenTyrian.app in build/, SDL2.framework bundled
     ./make_linux.sh    # SDL2 built from source and linked statically
     ./get_data.sh      # fetches the game data into data/ (both scripts call it)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,127 @@
+<img src="linux/icons/tyrian-128.png" width="128" height="128" align="right" alt="OpenTyrian icon">
+
+# OpenTyrian
+
+[![Linux](https://github.com/opentyrian/opentyrian/actions/workflows/linux.yml/badge.svg)](https://github.com/opentyrian/opentyrian/actions/workflows/linux.yml)
+[![macOS](https://github.com/opentyrian/opentyrian/actions/workflows/macos.yml/badge.svg)](https://github.com/opentyrian/opentyrian/actions/workflows/macos.yml)
+[![Windows](https://github.com/opentyrian/opentyrian/actions/workflows/windows.yml/badge.svg)](https://github.com/opentyrian/opentyrian/actions/workflows/windows.yml)
+
+OpenTyrian is an open-source port of the DOS game Tyrian.
+
+Tyrian is an arcade-style vertical scrolling shooter.  The story is set
+in 20,031 where you play as Trent Hawkins, a skilled fighter-pilot employed
+to fight MicroSol and save the galaxy.
+
+Tyrian features a story mode, one- and two-player arcade modes, and networked
+multiplayer.
+
+## Downloads
+
+Self-contained builds are attached to each
+[release](https://github.com/opentyrian/opentyrian/releases).  They include
+SDL2 and the freeware Tyrian 2.1 game data, so there is nothing to install:
+
+| Platform | File | Run |
+|---|---|---|
+| macOS (Apple Silicon and Intel) | `opentyrian-macos-universal.zip` | Unzip and open `OpenTyrian.app` |
+| Linux x86_64 / arm64 | `opentyrian-linux-<arch>.tar.gz` | Extract and run `./opentyrian` |
+| Windows x86_64 / arm64 | `opentyrian-windows-<arch>.zip` | Unzip and run `opentyrian.exe` |
+
+The macOS app is not notarized.  If Gatekeeper refuses to open it, right-click
+the app, choose *Open*, and confirm once.
+
+Configuration and saved games are kept per user, outside the game directory:
+
+| Platform | Location |
+|---|---|
+| Linux / macOS | `$XDG_CONFIG_HOME/opentyrian`, or `~/.config/opentyrian` |
+| Windows | `%APPDATA%\OpenTyrian` |
+
+## Game Data
+
+OpenTyrian needs the Tyrian 2.1 data files, which have been released as
+freeware: <https://camanis.net/tyrian/tyrian21.zip>
+
+The release builds above already contain them.  Otherwise, extract the
+archive so that the files (lowercase names) are in one of these places,
+searched in order:
+
+1. the directory given with `--data=DIR`
+2. a `data` directory next to the executable (inside `Contents/Resources`
+   for the macOS app)
+3. the system directory the build was configured with
+   (`/usr/local/share/games/tyrian` by default; `C:\TYRIAN` on Windows)
+4. a `data` directory in the current working directory
+
+`./get_data.sh [dir]` downloads and extracts them for you.  Filenames in the
+archive may be uppercase; the script lowercases them, as does
+`lower-script.sh` for an existing directory.
+
+## Building
+
+Requirements: a C99 compiler, GNU make, pkg-config, SDL2 and, for network
+play, SDL2_net.
+
+    make
+
+Network play is left out automatically when SDL2_net is not found
+(`make WITH_NETWORK=false` forces that; `WITH_NETWORK=true` requires it).
+`make debug` builds with `-Werror`, `-O0` and debug info.  `make install`
+honours `DESTDIR` and `prefix`.
+
+A Visual Studio solution is in `visualc/`.
+
+The self-contained release builds are produced by the same scripts CI uses:
+
+    ./make_mac.sh      # universal OpenTyrian.app in build/, SDL2.framework bundled
+    ./make_linux.sh    # SDL2 built from source and linked statically
+    ./get_data.sh      # fetches the game data into data/ (both scripts call it)
+
+The Linux script needs the development headers listed at the top of the file;
+SDL loads the matching X11, Wayland and audio backends at run time, so the
+resulting binary depends on nothing but glibc.  The Windows packages are
+built under MSYS2 by `.github/workflows/windows.yml`.
+
+## Command-Line Options
+
+    -h, --help                   Show help about options
+    -s, --no-sound               Disable audio
+    -j, --no-joystick            Disable joystick/gamepad input
+    -x, --no-xmas                Disable Christmas mode
+    -t, --data=DIR               Set Tyrian data directory
+    -n, --net=HOST[:PORT]        Start a networked game
+    --net-player-name=NAME       Set local player name in a networked game
+    --net-player-number=NUMBER   Set local player number in a networked game
+                                 (1 or 2)
+    -p, --net-port=PORT          Set local port to bind (default is 1333)
+    -d, --net-delay=FRAMES       Set lag-compensation delay (default is 1)
+
+## Keyboard Controls
+
+    alt-enter      -- toggle full-screen
+
+    arrow keys     -- ship movement
+    space          -- fire weapons
+    enter          -- toggle rear weapon mode
+    ctrl/alt       -- fire left/right sidekick
+
+## Network Multiplayer
+
+Currently OpenTyrian does not have an arena; as such, networked games must be
+initiated manually via the command line simultaneously by both players.
+
+syntax:
+
+    opentyrian --net HOSTNAME --net-player-name NAME --net-player-number NUMBER
+
+where HOSTNAME is the IP address of your opponent, NUMBER is either 1 or 2
+depending on which ship you intend to pilot, and NAME is your alias
+
+OpenTyrian uses UDP port 1333 for multiplayer, but in most cases players will
+not need to open any ports because OpenTyrian makes use of UDP hole punching.
+
+## Links
+
+- project: <https://github.com/opentyrian/opentyrian>
+- irc:     <ircs://irc.oftc.net/#opentyrian>
+- forums:  <https://tyrian2k.proboards.com/board/5>

--- a/doc/tyrian-data-license.txt
+++ b/doc/tyrian-data-license.txt
@@ -1,0 +1,16 @@
+Tyrian 2.1 game data
+====================
+
+The data files distributed alongside this build are the Tyrian 2.1 freeware
+release, downloaded from:
+
+    https://camanis.net/tyrian/tyrian21.zip
+
+Tyrian was created by Eclipse Productions and published by Epic MegaGames in
+1995.  The data files were later released as freeware.  No formal licence
+text accompanied that release; the statement given was:
+
+    "Feel free to play it all you want and share it with friends."
+
+The OpenTyrian source code and executable are covered separately by the GNU
+General Public License, version 2 or later.  See COPYING.

--- a/get_data.sh
+++ b/get_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# get_data.sh — fetch the freeware Tyrian 2.1 game data into a directory.
+# Idempotent: does nothing if the data is already there.
+#
+#   ./get_data.sh [dir]     (default: ./data)
+#
+# Tyrian 2.1 was released as freeware by its author; the zip is fetched from
+# the mirror the OpenTyrian README points at.  Filenames are stored in
+# lowercase, which is what the engine opens.
+set -euo pipefail
+
+DEST="${1:-$(dirname "$0")/data}"
+URL="https://camanis.net/tyrian/tyrian21.zip"
+
+have_data() { find "$1" -maxdepth 1 -iname "tyrian1.lvl" 2>/dev/null | grep -q .; }
+
+mkdir -p "$DEST"
+if have_data "$DEST"; then
+    echo "OK: game data already in $DEST"
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading Tyrian 2.1 (freeware, ~4 MB) from $URL ..."
+curl -fL --progress-bar -o "$TMP/tyrian21.zip" "$URL"
+unzip -q -o "$TMP/tyrian21.zip" -d "$TMP/x"
+
+# The archive may nest its files in a folder and name them in UPPERCASE.
+# Find the directory holding the level data and flatten it into DEST.
+probe=$(find "$TMP/x" -iname "tyrian1.lvl" | head -1)
+[ -n "$probe" ] || { echo "ERROR: download did not contain the expected game data" >&2; exit 1; }
+src=$(dirname "$probe")
+
+find "$src" -maxdepth 1 -type f | while read -r f; do
+    name=$(basename "$f" | tr '[:upper:]' '[:lower:]')
+    cp "$f" "$DEST/$name"
+done
+
+have_data "$DEST" || { echo "ERROR: game data copy failed" >&2; exit 1; }
+echo "OK: game data in $DEST"

--- a/make_icon.py
+++ b/make_icon.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""make_icon.py — build an .icns from a PNG (from the SkyRoads port).
+
+Input: 29x24 RGBA dump from cars_dump.  Output: .icns via iconutil.
+Stdlib only.  The icon is macOS-style: rounded dark space tile, starfield,
+ship pixel art scaled with nearest neighbor.
+"""
+import struct, sys, zlib, os, subprocess, random, tempfile
+
+CARW, CARH = 29, 24
+S = 1024                      # master size
+CORNER = 232                  # macOS icon-grid corner radius at 1024
+
+
+def write_png(path, w, h, rgba):
+    def chunk(tag, data):
+        c = struct.pack(">I", len(data)) + tag + data
+        return c + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+    raw = b"".join(b"\x00" + bytes(rgba[y * w * 4:(y + 1) * w * 4])
+                   for y in range(h))
+    png = (b"\x89PNG\r\n\x1a\n"
+           + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+           + chunk(b"IDAT", zlib.compress(raw, 9))
+           + chunk(b"IEND", b""))
+    open(path, "wb").write(png)
+
+
+def rounded_alpha(x, y):
+    rx = min(x, S - 1 - x)
+    ry = min(y, S - 1 - y)
+    if rx >= CORNER or ry >= CORNER:
+        return 255
+    dx, dy = CORNER - rx, CORNER - ry
+    d = (dx * dx + dy * dy) ** 0.5
+    if d <= CORNER - 1:
+        return 255
+    if d >= CORNER + 1:
+        return 0
+    return int(255 * (CORNER + 1 - d) / 2)
+
+
+def load_image_1024(path, td):
+    """Any image sips can read -> (S,S) RGB rows via BMP round-trip."""
+    bmp = os.path.join(td, "icon.bmp")
+    subprocess.run(["sips", "-s", "format", "bmp", "-z", str(S), str(S),
+                    path, "--out", bmp], check=True, capture_output=True)
+    d = open(bmp, "rb").read()
+    off = struct.unpack("<I", d[10:14])[0]
+    w, h = struct.unpack("<ii", d[18:26])
+    bpp = struct.unpack("<H", d[28:30])[0]
+    assert (w, abs(h), bpp) == (S, S, 24) or (w, abs(h), bpp) == (S, S, 32), "unexpected BMP"
+    stride = ((w * (bpp // 8) + 3) // 4) * 4
+    px = bytearray(S * S * 3)
+    for y in range(S):
+        src_y = (S - 1 - y) if h > 0 else y      # BMP bottom-up
+        row = off + src_y * stride
+        for x in range(S):
+            b, g, r = d[row + x * (bpp // 8):row + x * (bpp // 8) + 3]
+            i = (y * S + x) * 3
+            px[i:i + 3] = bytes((r, g, b))
+    return px
+
+
+def main_from_image(path, out_icns):
+    with tempfile.TemporaryDirectory() as td:
+        px = load_image_1024(path, td)
+        img = bytearray(S * S * 4)
+        for y in range(S):
+            for x in range(S):
+                a = rounded_alpha(x, y)
+                i3, i4 = (y * S + x) * 3, (y * S + x) * 4
+                img[i4:i4 + 4] = bytes((px[i3], px[i3 + 1], px[i3 + 2], a))
+        emit_iconset(img, out_icns, td)
+
+
+def emit_iconset(img, out_icns, td):
+    iconset = os.path.join(td, "OpenTyrian.iconset")
+    os.mkdir(iconset)
+    write_png(os.path.join(iconset, "icon_512x512@2x.png"), S, S, img)
+    for sz in (512, 256, 128, 64, 32, 16):
+        subprocess.run(["sips", "-z", str(sz), str(sz),
+                        os.path.join(iconset, "icon_512x512@2x.png"),
+                        "--out", os.path.join(iconset, f"icon_{sz}x{sz}.png")],
+                       check=True, capture_output=True)
+    subprocess.run(["iconutil", "-c", "icns", iconset, "-o", out_icns],
+                   check=True)
+
+
+def main(ship_bin, out_icns):
+    ship = open(ship_bin, "rb").read()
+    assert len(ship) == CARW * CARH * 4, "bad ship dump"
+
+    img = bytearray(S * S * 4)
+    rnd = random.Random(1993)                     # deterministic starfield
+    stars = [(rnd.randrange(40, S - 40), rnd.randrange(40, S - 40),
+              rnd.choice([120, 170, 220])) for _ in range(90)]
+    star_at = {}
+    for sx, sy, b in stars:
+        star_at[(sx, sy)] = b
+        if b > 150:                               # brighter stars get a cross
+            for d in (-1, 1):
+                star_at.setdefault((sx + d, sy), b // 2)
+                star_at.setdefault((sx, sy + d), b // 2)
+
+    # ship placement: nearest-neighbor scale, centered
+    scale = 28                                    # 29*28 = 812 px wide
+    shw, shh = CARW * scale, CARH * scale
+    ox, oy = (S - shw) // 2, (S - shh) // 2
+
+    for y in range(S):
+        for x in range(S):
+            a = rounded_alpha(x, y)
+            i = (y * S + x) * 4
+            if a == 0:
+                continue
+            # vertical space gradient: deep navy -> near black
+            t = y / S
+            r, g, b = int(14 + 10 * (1 - t)), int(14 + 8 * (1 - t)), int(40 + 26 * (1 - t))
+            sb = star_at.get((x, y))
+            if sb:
+                r, g, b = sb, sb, min(255, sb + 30)
+            # ship overlay
+            if ox <= x < ox + shw and oy <= y < oy + shh:
+                sx, sy = (x - ox) // scale, (y - oy) // scale
+                si = (sy * CARW + sx) * 4
+                if ship[si + 3]:
+                    r, g, b = ship[si], ship[si + 1], ship[si + 2]
+            img[i:i + 4] = bytes((r, g, b, a))
+
+    with tempfile.TemporaryDirectory() as td:
+        emit_iconset(img, out_icns, td)
+
+
+if __name__ == "__main__":
+    if sys.argv[1].endswith(".bin"):
+        main(sys.argv[1], sys.argv[2])
+    else:
+        main_from_image(sys.argv[1], sys.argv[2])

--- a/make_icon.py
+++ b/make_icon.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
-"""make_icon.py — build an .icns from a PNG (from the SkyRoads port).
+"""make_icon.py — build a macOS .icns from a PNG.
 
-Input: 29x24 RGBA dump from cars_dump.  Output: .icns via iconutil.
-Stdlib only.  The icon is macOS-style: rounded dark space tile, starfield,
-ship pixel art scaled with nearest neighbor.
+    ./make_icon.py icon.png OpenTyrian.icns
+
+The image is scaled to 1024x1024 and given the rounded-square mask macOS
+icons use, then handed to iconutil.  Standard library only; sips and
+iconutil ship with macOS.
 """
-import struct, sys, zlib, os, subprocess, random, tempfile
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
 
-CARW, CARH = 29, 24
 S = 1024                      # master size
 CORNER = 232                  # macOS icon-grid corner radius at 1024
 
@@ -61,18 +67,6 @@ def load_image_1024(path, td):
     return px
 
 
-def main_from_image(path, out_icns):
-    with tempfile.TemporaryDirectory() as td:
-        px = load_image_1024(path, td)
-        img = bytearray(S * S * 4)
-        for y in range(S):
-            for x in range(S):
-                a = rounded_alpha(x, y)
-                i3, i4 = (y * S + x) * 3, (y * S + x) * 4
-                img[i4:i4 + 4] = bytes((px[i3], px[i3 + 1], px[i3 + 2], a))
-        emit_iconset(img, out_icns, td)
-
-
 def emit_iconset(img, out_icns, td):
     iconset = os.path.join(td, "OpenTyrian.iconset")
     os.mkdir(iconset)
@@ -86,53 +80,19 @@ def emit_iconset(img, out_icns, td):
                    check=True)
 
 
-def main(ship_bin, out_icns):
-    ship = open(ship_bin, "rb").read()
-    assert len(ship) == CARW * CARH * 4, "bad ship dump"
-
-    img = bytearray(S * S * 4)
-    rnd = random.Random(1993)                     # deterministic starfield
-    stars = [(rnd.randrange(40, S - 40), rnd.randrange(40, S - 40),
-              rnd.choice([120, 170, 220])) for _ in range(90)]
-    star_at = {}
-    for sx, sy, b in stars:
-        star_at[(sx, sy)] = b
-        if b > 150:                               # brighter stars get a cross
-            for d in (-1, 1):
-                star_at.setdefault((sx + d, sy), b // 2)
-                star_at.setdefault((sx, sy + d), b // 2)
-
-    # ship placement: nearest-neighbor scale, centered
-    scale = 28                                    # 29*28 = 812 px wide
-    shw, shh = CARW * scale, CARH * scale
-    ox, oy = (S - shw) // 2, (S - shh) // 2
-
-    for y in range(S):
-        for x in range(S):
-            a = rounded_alpha(x, y)
-            i = (y * S + x) * 4
-            if a == 0:
-                continue
-            # vertical space gradient: deep navy -> near black
-            t = y / S
-            r, g, b = int(14 + 10 * (1 - t)), int(14 + 8 * (1 - t)), int(40 + 26 * (1 - t))
-            sb = star_at.get((x, y))
-            if sb:
-                r, g, b = sb, sb, min(255, sb + 30)
-            # ship overlay
-            if ox <= x < ox + shw and oy <= y < oy + shh:
-                sx, sy = (x - ox) // scale, (y - oy) // scale
-                si = (sy * CARW + sx) * 4
-                if ship[si + 3]:
-                    r, g, b = ship[si], ship[si + 1], ship[si + 2]
-            img[i:i + 4] = bytes((r, g, b, a))
-
+def main(path, out_icns):
     with tempfile.TemporaryDirectory() as td:
+        px = load_image_1024(path, td)
+        img = bytearray(S * S * 4)
+        for y in range(S):
+            for x in range(S):
+                a = rounded_alpha(x, y)
+                i3, i4 = (y * S + x) * 3, (y * S + x) * 4
+                img[i4:i4 + 4] = bytes((px[i3], px[i3 + 1], px[i3 + 2], a))
         emit_iconset(img, out_icns, td)
 
 
 if __name__ == "__main__":
-    if sys.argv[1].endswith(".bin"):
-        main(sys.argv[1], sys.argv[2])
-    else:
-        main_from_image(sys.argv[1], sys.argv[2])
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <image> <out.icns>")
+    main(sys.argv[1], sys.argv[2])

--- a/make_linux.sh
+++ b/make_linux.sh
@@ -45,13 +45,15 @@ NPROC="$(nproc 2>/dev/null || echo 4)"
 # copies inside the prefix, since that is what CI caches: on a cache hit the
 # source trees below are never unpacked.
 install_license() {  # $1 = source directory, $2 = name in the package
-    src=$(ls "$1"/LICENSE.txt "$1"/LICENSE "$1"/COPYING.txt "$1"/COPYING 2>/dev/null | head -1)
-    if [ -z "$src" ]; then
-        echo "ERROR: no licence file found in $1" >&2
-        exit 1
-    fi
     mkdir -p "$PREFIX/share/licenses"
-    cp "$src" "$PREFIX/share/licenses/$2.txt"
+    for name in LICENSE.txt LICENSE COPYING.txt COPYING; do
+        if [ -f "$1/$name" ]; then
+            cp "$1/$name" "$PREFIX/share/licenses/$2.txt"
+            return 0
+        fi
+    done
+    echo "ERROR: no licence file found in $1" >&2
+    exit 1
 }
 
 if [ ! -f "$PREFIX/lib/libSDL2.a" ]; then

--- a/make_linux.sh
+++ b/make_linux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# make_linux.sh — build a self-contained OpenTyrian binary on Linux.
+#
+# SDL2 and SDL2_net are built from source and linked STATICALLY.  A distro's
+# libSDL2 is linked against whatever that distro has (libdecor, Wayland,
+# PulseAudio, PipeWire...), and bundling it drags every one of those in as a
+# hard dependency on the user's machine.  SDL built from source instead
+# loads all of those backends with dlopen at run time, so the resulting
+# binary needs nothing beyond glibc and libm - and whatever the user has
+# (X11 or Wayland, ALSA or Pulse) gets picked up when it runs.
+#
+# The freeware Tyrian 2.1 data is fetched into ./data if missing.
+#
+# Build requirements (headers only; nothing is linked from them):
+#   Debian/Ubuntu:  sudo apt install build-essential cmake pkg-config curl unzip \
+#       libasound2-dev libpulse-dev libx11-dev libxext-dev libxrandr-dev \
+#       libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
+#       libxkbcommon-dev libdecor-0-dev libegl1-mesa-dev libgl1-mesa-dev \
+#       libdbus-1-dev libudev-dev
+#
+# Usage: ./make_linux.sh [data-dir]     (default: ./data, fetched if missing)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+DATA_ARG="${1:-data}"
+
+have_data() { find "$1" -maxdepth 1 -iname "tyrian1.lvl" 2>/dev/null | grep -q .; }
+
+if ! have_data "$DATA_ARG" && [ "$#" -ge 1 ]; then
+    echo "ERROR: no Tyrian data in '$DATA_ARG'" >&2
+    echo "Point make_linux.sh at your Tyrian 2.1 data, or run it with no argument" >&2
+    echo "to download the freeware release into ./data automatically." >&2
+    exit 1
+fi
+./get_data.sh "$DATA_ARG"
+DATA_DIR="$(cd "$DATA_ARG" && pwd)"
+
+# ---- static SDL2 + SDL2_net from source, installed under build/sdl ----
+SDL2_VER="2.32.10"
+SDL2_NET_VER="2.2.0"
+PREFIX="$PWD/build/sdl"
+NPROC="$(nproc 2>/dev/null || echo 4)"
+
+if [ ! -f "$PREFIX/lib/libSDL2.a" ]; then
+    echo "Building SDL2 $SDL2_VER (static) ..."
+    mkdir -p build/vendor
+    curl -fL --progress-bar -o build/vendor/SDL2.tar.gz \
+        "https://github.com/libsdl-org/SDL/releases/download/release-$SDL2_VER/SDL2-$SDL2_VER.tar.gz"
+    rm -rf "build/vendor/SDL2-$SDL2_VER"
+    tar -xzf build/vendor/SDL2.tar.gz -C build/vendor
+    cmake -S "build/vendor/SDL2-$SDL2_VER" -B "build/vendor/SDL2-$SDL2_VER/build" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+        -DSDL_SHARED=OFF -DSDL_STATIC=ON -DSDL_STATIC_PIC=ON -DSDL_TEST=OFF >/dev/null
+    cmake --build "build/vendor/SDL2-$SDL2_VER/build" -j"$NPROC" >/dev/null
+    cmake --install "build/vendor/SDL2-$SDL2_VER/build" >/dev/null
+fi
+
+if [ ! -f "$PREFIX/lib/libSDL2_net.a" ]; then
+    echo "Building SDL2_net $SDL2_NET_VER (static) ..."
+    mkdir -p build/vendor
+    curl -fL --progress-bar -o build/vendor/SDL2_net.tar.gz \
+        "https://github.com/libsdl-org/SDL_net/releases/download/release-$SDL2_NET_VER/SDL2_net-$SDL2_NET_VER.tar.gz"
+    rm -rf "build/vendor/SDL2_net-$SDL2_NET_VER"
+    tar -xzf build/vendor/SDL2_net.tar.gz -C build/vendor
+    cmake -S "build/vendor/SDL2_net-$SDL2_NET_VER" -B "build/vendor/SDL2_net-$SDL2_NET_VER/build" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" \
+        -DBUILD_SHARED_LIBS=OFF -DSDL2NET_SAMPLES=OFF >/dev/null
+    cmake --build "build/vendor/SDL2_net-$SDL2_NET_VER/build" -j"$NPROC" >/dev/null
+    cmake --install "build/vendor/SDL2_net-$SDL2_NET_VER/build" >/dev/null
+fi
+
+# ---- the game, against the static SDL ----
+# pkg-config resolves sdl2/SDL2_net from our prefix; --static pulls in the
+# libraries SDL itself needs (m, dl, pthread, rt) for the static link.
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+make clean >/dev/null
+make -j"$NPROC" \
+    SDL_LDLIBS="$(pkg-config --static --libs-only-l sdl2 SDL2_net)"
+
+echo
+if ldd opentyrian | grep -q "libSDL2"; then
+    echo "ERROR: opentyrian still links SDL2 dynamically" >&2
+    exit 1
+fi
+echo "built: ./opentyrian (SDL2 linked statically)"
+echo "run:   ./opentyrian --data=\"$DATA_DIR\""

--- a/make_linux.sh
+++ b/make_linux.sh
@@ -41,6 +41,19 @@ SDL2_NET_VER="2.2.0"
 PREFIX="$PWD/build/sdl"
 NPROC="$(nproc 2>/dev/null || echo 4)"
 
+# The licence of anything we link in has to travel with the binary.  Keep the
+# copies inside the prefix, since that is what CI caches: on a cache hit the
+# source trees below are never unpacked.
+install_license() {  # $1 = source directory, $2 = name in the package
+    src=$(ls "$1"/LICENSE.txt "$1"/LICENSE "$1"/COPYING.txt "$1"/COPYING 2>/dev/null | head -1)
+    if [ -z "$src" ]; then
+        echo "ERROR: no licence file found in $1" >&2
+        exit 1
+    fi
+    mkdir -p "$PREFIX/share/licenses"
+    cp "$src" "$PREFIX/share/licenses/$2.txt"
+}
+
 if [ ! -f "$PREFIX/lib/libSDL2.a" ]; then
     echo "Building SDL2 $SDL2_VER (static) ..."
     mkdir -p build/vendor
@@ -53,6 +66,7 @@ if [ ! -f "$PREFIX/lib/libSDL2.a" ]; then
         -DSDL_SHARED=OFF -DSDL_STATIC=ON -DSDL_STATIC_PIC=ON -DSDL_TEST=OFF >/dev/null
     cmake --build "build/vendor/SDL2-$SDL2_VER/build" -j"$NPROC" >/dev/null
     cmake --install "build/vendor/SDL2-$SDL2_VER/build" >/dev/null
+    install_license "build/vendor/SDL2-$SDL2_VER" SDL2
 fi
 
 if [ ! -f "$PREFIX/lib/libSDL2_net.a" ]; then
@@ -67,6 +81,7 @@ if [ ! -f "$PREFIX/lib/libSDL2_net.a" ]; then
         -DBUILD_SHARED_LIBS=OFF -DSDL2NET_SAMPLES=OFF >/dev/null
     cmake --build "build/vendor/SDL2_net-$SDL2_NET_VER/build" -j"$NPROC" >/dev/null
     cmake --install "build/vendor/SDL2_net-$SDL2_NET_VER/build" >/dev/null
+    install_license "build/vendor/SDL2_net-$SDL2_NET_VER" SDL2_net
 fi
 
 # ---- the game, against the static SDL ----

--- a/make_mac.sh
+++ b/make_mac.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# make_mac.sh — build a self-contained, universal OpenTyrian.app (macOS).
+# Bundles the official SDL2.framework and the freeware Tyrian 2.1 data, so
+# the app runs on any Mac with nothing installed.
+#
+# Usage: ./make_mac.sh [data-dir]     (default: ./data, fetched if missing)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+DATA_ARG="${1:-data}"
+
+have_data() { find "$1" -maxdepth 1 -iname "tyrian1.lvl" 2>/dev/null | grep -q .; }
+
+if ! have_data "$DATA_ARG" && [ "$#" -ge 1 ]; then
+    echo "ERROR: no Tyrian data in '$DATA_ARG'" >&2
+    echo "Point make_mac.sh at your Tyrian 2.1 data, or run it with no argument" >&2
+    echo "to download the freeware release into ./data automatically." >&2
+    exit 1
+fi
+./get_data.sh "$DATA_ARG"
+DATA_DIR="$(cd "$DATA_ARG" && pwd)"
+
+OUT="build/OpenTyrian.app"
+
+# ---- official universal SDL2.framework (arm64 + x86_64), cached ----
+SDL2_VER="2.32.10"
+FW="$PWD/build/vendor/SDL2.framework"
+if [ ! -d "$FW" ]; then
+    echo "Downloading SDL2 $SDL2_VER framework (universal, ~2 MB) ..."
+    mkdir -p build/vendor
+    curl -fL --progress-bar -o build/vendor/SDL2.dmg \
+        "https://github.com/libsdl-org/SDL/releases/download/release-$SDL2_VER/SDL2-$SDL2_VER.dmg"
+    MNT=$(mktemp -d)
+    hdiutil attach build/vendor/SDL2.dmg -nobrowse -quiet -mountpoint "$MNT"
+    cp -R "$MNT/SDL2.framework" build/vendor/
+    hdiutil detach "$MNT" -quiet
+    rm build/vendor/SDL2.dmg
+fi
+FW_DIR="$(dirname "$FW")"
+
+# ---- one build per architecture, then lipo them together ----
+# The Makefile's SDL_* variables normally come from pkg-config; overriding
+# them on the command line points the build at the framework instead.
+# Networking is off: the release has no SDL2_net framework to bundle.
+build_arch() {  # $1 = arm64 | x86_64
+    make clean >/dev/null
+    make -j"$(sysctl -n hw.ncpu)" \
+        CC="cc -arch $1 -mmacosx-version-min=10.13" \
+        WITH_NETWORK=false \
+        SDL_CPPFLAGS="-I$FW/Headers -F$FW_DIR" \
+        SDL_LDFLAGS="-F$FW_DIR -Wl,-rpath,@executable_path/../Frameworks" \
+        SDL_LDLIBS="-framework SDL2" >/dev/null
+    mv opentyrian "build/opentyrian-$1"
+}
+mkdir -p build
+build_arch arm64
+build_arch x86_64
+lipo -create -output build/opentyrian-universal build/opentyrian-arm64 build/opentyrian-x86_64
+
+# ---- assemble the bundle ----
+rm -rf "$OUT"
+mkdir -p "$OUT/Contents/MacOS" "$OUT/Contents/Resources" "$OUT/Contents/Frameworks"
+
+VERSION="$( (git describe --tags || git rev-parse --short HEAD) 2>/dev/null || echo dev)"
+cat > "$OUT/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>      <string>opentyrian</string>
+    <key>CFBundleIdentifier</key>      <string>org.opentyrian.OpenTyrian</string>
+    <key>CFBundleName</key>            <string>OpenTyrian</string>
+    <key>CFBundleDisplayName</key>     <string>OpenTyrian</string>
+    <key>CFBundlePackageType</key>     <string>APPL</string>
+    <key>CFBundleShortVersionString</key> <string>$VERSION</string>
+    <key>CFBundleIconFile</key>        <string>OpenTyrian</string>
+    <key>LSMinimumSystemVersion</key>  <string>10.13</string>
+    <key>NSHighResolutionCapable</key> <true/>
+</dict>
+</plist>
+PLIST
+
+cp build/opentyrian-universal "$OUT/Contents/MacOS/opentyrian"
+
+# SDL2.framework, headers stripped
+cp -R "$FW" "$OUT/Contents/Frameworks/"
+rm -rf "$OUT/Contents/Frameworks/SDL2.framework/Headers" \
+       "$OUT/Contents/Frameworks/SDL2.framework/Versions/A/Headers"
+
+# Game data: the engine looks in <bundle>/Contents/Resources/data (lowercase names)
+mkdir -p "$OUT/Contents/Resources/data"
+find "$DATA_DIR" -maxdepth 1 -type f | while read -r f; do
+    cp "$f" "$OUT/Contents/Resources/data/$(basename "$f" | tr '[:upper:]' '[:lower:]')"
+done
+
+# App icon from the 128px Linux icon
+python3 make_icon.py linux/icons/tyrian-128.png "$OUT/Contents/Resources/OpenTyrian.icns" \
+    && echo "icon: from linux/icons/tyrian-128.png" || echo "note: icon generation failed, skipping"
+
+codesign --force -s - "$OUT/Contents/Frameworks/SDL2.framework"
+codesign --force -s - "$OUT"
+touch "$OUT"
+echo "built: $OUT"

--- a/make_macos.sh
+++ b/make_macos.sh
@@ -94,6 +94,13 @@ find "$DATA_DIR" -maxdepth 1 -type f | while read -r f; do
     cp "$f" "$OUT/Contents/Resources/data/$(basename "$f" | tr '[:upper:]' '[:lower:]')"
 done
 
+# Licences.  SDL2's travels inside the framework already, but three levels
+# down where nobody would look for it.
+cp COPYING "$OUT/Contents/Resources/COPYING"
+mkdir -p "$OUT/Contents/Resources/licenses"
+cp "$FW/Versions/A/Resources/License.txt" "$OUT/Contents/Resources/licenses/SDL2.txt"
+cp doc/tyrian-data-license.txt "$OUT/Contents/Resources/licenses/tyrian-data.txt"
+
 # App icon from the 128px Linux icon
 python3 make_icon.py linux/icons/tyrian-128.png "$OUT/Contents/Resources/OpenTyrian.icns" \
     && echo "icon: from linux/icons/tyrian-128.png" || echo "note: icon generation failed, skipping"

--- a/make_macos.sh
+++ b/make_macos.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# make_mac.sh — build a self-contained, universal OpenTyrian.app (macOS).
+# make_macos.sh — build a self-contained, universal OpenTyrian.app (macOS).
 # Bundles the official SDL2.framework and the freeware Tyrian 2.1 data, so
 # the app runs on any Mac with nothing installed.
 #
-# Usage: ./make_mac.sh [data-dir]     (default: ./data, fetched if missing)
+# Usage: ./make_macos.sh [data-dir]     (default: ./data, fetched if missing)
 set -euo pipefail
 
 cd "$(dirname "$0")"
@@ -13,7 +13,7 @@ have_data() { find "$1" -maxdepth 1 -iname "tyrian1.lvl" 2>/dev/null | grep -q .
 
 if ! have_data "$DATA_ARG" && [ "$#" -ge 1 ]; then
     echo "ERROR: no Tyrian data in '$DATA_ARG'" >&2
-    echo "Point make_mac.sh at your Tyrian 2.1 data, or run it with no argument" >&2
+    echo "Point make_macos.sh at your Tyrian 2.1 data, or run it with no argument" >&2
     echo "to download the freeware release into ./data automatically." >&2
     exit 1
 fi
@@ -69,7 +69,7 @@ cat > "$OUT/Contents/Info.plist" <<PLIST
 <plist version="1.0">
 <dict>
     <key>CFBundleExecutable</key>      <string>opentyrian</string>
-    <key>CFBundleIdentifier</key>      <string>org.opentyrian.OpenTyrian</string>
+    <key>CFBundleIdentifier</key>      <string>io.github.opentyrian.OpenTyrian</string>
     <key>CFBundleName</key>            <string>OpenTyrian</string>
     <key>CFBundleDisplayName</key>     <string>OpenTyrian</string>
     <key>CFBundlePackageType</key>     <string>APPL</string>

--- a/src/file.c
+++ b/src/file.c
@@ -78,8 +78,24 @@ bool findDataFiles(void)
 		return dataFileExists(filename);
 	}
 
+	// A "data" directory next to the executable (or inside the app bundle's
+	// Resources on macOS), so a self-contained distribution runs from any cwd.
+	static char *baseDataDirPath = NULL;
+	if (baseDataDirPath == NULL)
+	{
+		char *basePath = SDL_GetBasePath();
+		if (basePath != NULL)
+		{
+			size_t baseDataDirPathSize = strlen(basePath) + strlen("data") + 1;
+			baseDataDirPath = malloc(baseDataDirPathSize);
+			snprintf(baseDataDirPath, baseDataDirPathSize, "%sdata", basePath);
+			SDL_free(basePath);
+		}
+	}
+
 	const char *dataDirPaths[] =
 	{
+		baseDataDirPath,
 #ifdef TYRIAN_DIR
 		TYRIAN_DIR,
 #endif

--- a/src/file.c
+++ b/src/file.c
@@ -99,7 +99,6 @@ bool findDataFiles(void)
 #ifdef TYRIAN_DIR
 		TYRIAN_DIR,
 #endif
-		"data",
 	};
 
 	for (size_t i = 0; i < COUNTOF(dataDirPaths); ++i)


### PR DESCRIPTION
Three workflows build on every push and pull request, and attach packages to published releases. Each runs a `debug` build under `-Werror`, then builds a self-contained package and verifies it:

- **macOS:** a universal `OpenTyrian.app` (arm64 + x86_64) with SDL2.framework bundled.
- **Linux:** x86_64 and arm64 tarballs with SDL2 and SDL2_net built from source and linked statically, so the binary depends on glibc only. Verified by running the tarball inside a bare Debian container.
- **Windows:** x86_64 and arm64 zips with the needed DLLs, built under MSYS2.

The packages include the freeware Tyrian 2.1 data, fetched from the URL the README already lists. That is one step in the scripts and easy to drop if the project would rather not redistribute it.

Getting this green needed four small fixes, each in its own commit:

- `-Wno-format-truncation` is GCC-only; Clang rejects it and `-Werror` turned that into a hard failure of `make debug`. It is now passed to GCC only.
- `WITH_NETWORK` defaults to `auto`: a machine without SDL2_net builds without network play (and says so) instead of failing. Explicit `true`/`false` behave as before.
- The Windows target is `opentyrian.exe`, matching what MinGW produces and what `.gitignore` already expects, so `clean` and `install` reference the real file.
- A `data` directory next to the executable is searched before `TYRIAN_DIR` and the cwd, so a package runs from wherever it is launched and a self-contained copy uses its own data even on a machine with a system install.

A README.md is added alongside the existing README, which is kept unchanged because the AppVeyor packaging step copies it by name. GitHub renders the markdown one. It adds the icon, per-platform build badges, a downloads table, the data search order, build instructions and the command-line options. If you would rather have a single file, either can go.